### PR TITLE
Fix inventory stock drift from fractional quantity truncation (P0-1)

### DIFF
--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -39,8 +39,8 @@ class InventoryItem(TimestampMixin, SoftDeleteMixin, AuditMixin, db.Model):
     markup_percent = db.Column(db.Numeric(5, 2), nullable=True)
 
     # --- Stock ---
-    quantity_in_stock = db.Column(db.Integer, nullable=False, default=0)
-    reorder_level = db.Column(db.Integer, nullable=False, default=0)
+    quantity_in_stock = db.Column(db.Numeric(10, 2), nullable=False, default=0)
+    reorder_level = db.Column(db.Numeric(10, 2), nullable=False, default=0)
     reorder_quantity = db.Column(db.Integer, nullable=True)
     unit_of_measure = db.Column(
         db.String(50), nullable=False, default="each"

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -403,7 +403,7 @@ def remove_order_item(order_item_id):
     for part in order_item.parts_used.all():
         inv_item = db.session.get(InventoryItem, part.inventory_item_id)
         if inv_item is not None:
-            inv_item.quantity_in_stock += round(part.quantity)
+            inv_item.quantity_in_stock += part.quantity
 
     db.session.delete(order_item)
     db.session.commit()
@@ -499,7 +499,7 @@ def add_applied_service(order_item_id, data, added_by=None):
         for linked_part in price_list_item.linked_parts.all():
             inv_item = db.session.get(InventoryItem, linked_part.inventory_item_id)
             if inv_item is not None:
-                part_qty = round(linked_part.quantity)
+                part_qty = linked_part.quantity
                 add_part_used(
                     order_item_id=order_item_id,
                     inventory_item_id=linked_part.inventory_item_id,
@@ -540,7 +540,7 @@ def remove_applied_service(applied_service_id):
     for part in auto_parts:
         inv_item = db.session.get(InventoryItem, part.inventory_item_id)
         if inv_item is not None:
-            inv_item.quantity_in_stock += round(part.quantity)
+            inv_item.quantity_in_stock += part.quantity
         db.session.delete(part)
 
     db.session.delete(applied)
@@ -609,7 +609,7 @@ def add_part_used(
     db.session.add(part)
 
     # Deduct from inventory stock
-    inv_item.quantity_in_stock -= round(quantity)
+    inv_item.quantity_in_stock -= quantity
 
     # Only commit if this is a standalone call (not nested inside
     # add_applied_service which manages its own commit).
@@ -638,7 +638,7 @@ def remove_part_used(part_used_id):
     # Restore inventory
     inv_item = db.session.get(InventoryItem, part.inventory_item_id)
     if inv_item is not None:
-        inv_item.quantity_in_stock += round(part.quantity)
+        inv_item.quantity_in_stock += part.quantity
 
     db.session.delete(part)
     db.session.commit()

--- a/migrations/versions/p0_1_inventory_decimal_stock_columns.py
+++ b/migrations/versions/p0_1_inventory_decimal_stock_columns.py
@@ -1,0 +1,58 @@
+"""P0-1: Change inventory stock columns from Integer to Numeric(10,2)
+
+Allows fractional inventory quantities (e.g. 2.5 ft of tape) to be
+tracked without truncation.  Fixes stock drift caused by int() casts
+on decimal part quantities.
+
+Revision ID: a1b2c3d4e5f6
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-08 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'inventory_items',
+        'quantity_in_stock',
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(precision=10, scale=2),
+        existing_nullable=False,
+        existing_server_default=sa.text('0'),
+    )
+    op.alter_column(
+        'inventory_items',
+        'reorder_level',
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(precision=10, scale=2),
+        existing_nullable=False,
+        existing_server_default=sa.text('0'),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'inventory_items',
+        'reorder_level',
+        existing_type=sa.Numeric(precision=10, scale=2),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        existing_server_default=sa.text('0'),
+    )
+    op.alter_column(
+        'inventory_items',
+        'quantity_in_stock',
+        existing_type=sa.Numeric(precision=10, scale=2),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        existing_server_default=sa.text('0'),
+    )

--- a/tests/unit/services/test_order_service.py
+++ b/tests/unit/services/test_order_service.py
@@ -477,6 +477,26 @@ class TestPartsUsed:
         result = order_service.remove_part_used(99999)
         assert result is False
 
+    def test_fractional_quantity_deducted_exactly(self, app, db_session):
+        """Fractional part quantities are deducted exactly, with no rounding."""
+        order = _make_order(db_session)
+        si = _make_service_item(db_session)
+        oi = _make_order_item(db_session, order=order, service_item=si)
+        inv = _make_inventory_item(
+            db_session,
+            sku="SKU-FRAC-01",
+            quantity_in_stock=Decimal("10.00"),
+        )
+
+        order_service.add_part_used(
+            order_item_id=oi.id,
+            inventory_item_id=inv.id,
+            quantity=Decimal("2.75"),
+        )
+
+        db_session.refresh(inv)
+        assert inv.quantity_in_stock == Decimal("7.25")
+
 
 # =========================================================================
 # Labor Entries

--- a/tests/validation/test_full_workflow.py
+++ b/tests/validation/test_full_workflow.py
@@ -169,10 +169,9 @@ class TestFullServiceWorkflow:
             )
             assert adhesive_used is not None
 
-            # Verify fractional deduction uses round()
+            # Verify exact fractional deduction (no rounding)
             db_session.refresh(adhesive)
-            # round(2.5) = 2 on Python (banker's rounding), but stock was 20
-            expected_adhesive = 20 - round(Decimal("2.5"))
+            expected_adhesive = Decimal("20") - Decimal("2.5")  # = 17.5
             assert adhesive.quantity_in_stock == expected_adhesive
 
             # ── 11. Add labor entry ─────────────────────────────


### PR DESCRIPTION
## Summary
- **P0-1 Critical**: Inventory deductions used `round()` on decimal quantities, causing billed amounts to diverge from actual stock changes. Over time this compounds into significant stock drift.
- Changed `quantity_in_stock` and `reorder_level` columns from `Integer` to `Numeric(10,2)` to support fractional units (e.g., 2.5 ft of tape)
- Removed 5 `round()` calls in `order_service.py` stock math (add_part, remove_part, add_applied_service, remove_applied_service, remove_order_item)
- Added Alembic migration `a1b2c3d4e5f6` for the column type change

## Test plan
- [x] New test: `test_fractional_quantity_deducted_exactly` verifies 2.75 deducted from 10.00 = 7.25
- [x] Updated validation workflow test to expect exact 17.5 instead of rounded 18
- [x] Full suite: 762 tests passing