### PR TITLE
Fix broadcast notification read state leaking between users (P0-2)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.applied_service import AppliedService
 from app.models.invoice import Invoice, InvoiceLineItem, invoice_orders
 from app.models.payment import Payment
 from app.models.notification import Notification
+from app.models.notification_read import NotificationRead
 
 __all__ = [
     "Role",
@@ -46,4 +47,5 @@ __all__ = [
     "invoice_orders",
     "Payment",
     "Notification",
+    "NotificationRead",
 ]

--- a/app/models/notification_read.py
+++ b/app/models/notification_read.py
@@ -1,0 +1,36 @@
+"""Notification read-tracking for per-user broadcast state.
+
+Broadcast notifications (where notification.user_id is NULL) are visible to
+all users.  Rather than flipping a single ``is_read`` flag on the shared
+notification row, each user gets their own NotificationRead record when they
+dismiss / read the broadcast.
+"""
+
+from app.extensions import db
+
+
+class NotificationRead(db.Model):
+    """Per-user read receipt for broadcast notifications."""
+
+    __tablename__ = "notification_reads"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    notification_id = db.Column(
+        db.Integer,
+        db.ForeignKey("notifications.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    read_at = db.Column(db.DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "notification_id", "user_id", name="uq_notification_user_read"
+        ),
+    )
+
+    notification = db.relationship("Notification", backref="reads")

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -7,8 +7,11 @@ such as low-stock alerts, order status changes, and payment receipts.
 
 from datetime import datetime, timezone
 
+from sqlalchemy import and_
+
 from app.extensions import db
 from app.models.notification import Notification
+from app.models.notification_read import NotificationRead
 from app.models.user import Role, User
 
 
@@ -57,7 +60,8 @@ def get_notifications(user_id, unread_only=False, page=1, per_page=20):
     """Return paginated notifications for a user, newest first.
 
     Includes both user-targeted notifications and broadcast notifications
-    (where user_id is NULL).
+    (where user_id is NULL).  For broadcasts, "unread" means no
+    :class:`NotificationRead` row exists for the given *user_id*.
 
     Args:
         user_id: The user ID to fetch notifications for.
@@ -68,15 +72,31 @@ def get_notifications(user_id, unread_only=False, page=1, per_page=20):
     Returns:
         A SQLAlchemy pagination object.
     """
-    query = Notification.query.filter(
-        db.or_(
-            Notification.user_id == user_id,
-            Notification.user_id.is_(None),
-        )
-    )
-
     if unread_only:
-        query = query.filter(Notification.is_read == False)  # noqa: E712
+        # Direct (user-targeted) unread notifications
+        direct_unread = Notification.query.filter(
+            Notification.user_id == user_id,
+            Notification.is_read == False,  # noqa: E712
+        )
+        # Broadcast notifications without a read receipt for this user
+        broadcast_unread = Notification.query.outerjoin(
+            NotificationRead,
+            and_(
+                NotificationRead.notification_id == Notification.id,
+                NotificationRead.user_id == user_id,
+            ),
+        ).filter(
+            Notification.user_id.is_(None),
+            NotificationRead.id.is_(None),
+        )
+        query = direct_unread.union(broadcast_unread)
+    else:
+        query = Notification.query.filter(
+            db.or_(
+                Notification.user_id == user_id,
+                Notification.user_id.is_(None),
+            )
+        )
 
     query = query.order_by(Notification.created_at.desc())
 
@@ -86,7 +106,8 @@ def get_notifications(user_id, unread_only=False, page=1, per_page=20):
 def get_unread_count(user_id):
     """Return the count of unread notifications for a user.
 
-    Counts both user-targeted and broadcast notifications.
+    Counts direct unread notifications (``is_read=False``) **plus** broadcast
+    notifications that have no :class:`NotificationRead` row for *user_id*.
 
     Args:
         user_id: The user ID to count unread notifications for.
@@ -94,23 +115,36 @@ def get_unread_count(user_id):
     Returns:
         An integer count of unread notifications.
     """
-    return Notification.query.filter(
-        db.or_(
-            Notification.user_id == user_id,
-            Notification.user_id.is_(None),
-        ),
+    # Direct (user-targeted) unread count
+    direct_count = Notification.query.filter(
+        Notification.user_id == user_id,
         Notification.is_read == False,  # noqa: E712
     ).count()
+
+    # Broadcast notifications this user has NOT read
+    broadcast_count = Notification.query.outerjoin(
+        NotificationRead,
+        and_(
+            NotificationRead.notification_id == Notification.id,
+            NotificationRead.user_id == user_id,
+        ),
+    ).filter(
+        Notification.user_id.is_(None),
+        NotificationRead.id.is_(None),
+    ).count()
+
+    return direct_count + broadcast_count
 
 
 def mark_as_read(notification_id, user_id=None):
     """Mark a single notification as read.
 
-    Sets ``is_read`` to True and records the ``read_at`` timestamp.
+    For **direct** notifications (``notification.user_id`` is set), this sets
+    ``is_read=True`` and records ``read_at`` on the notification row itself.
 
-    When *user_id* is provided the function verifies that the notification
-    belongs to that user before updating it.  Broadcast notifications
-    (``notification.user_id is None``) may be marked as read by any user.
+    For **broadcast** notifications (``notification.user_id is None``), a
+    per-user :class:`NotificationRead` row is inserted instead, so that other
+    users' read state is unaffected.
 
     Args:
         notification_id: The primary key of the notification.
@@ -126,40 +160,88 @@ def mark_as_read(notification_id, user_id=None):
     if notification is None:
         return None
 
-    if user_id is not None:
-        if notification.user_id is not None and notification.user_id != user_id:
+    # --- Direct (user-targeted) notification ---
+    if notification.user_id is not None:
+        if user_id is not None and notification.user_id != user_id:
             return None
+        notification.is_read = True
+        notification.read_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return notification
 
-    notification.is_read = True
-    notification.read_at = datetime.now(timezone.utc)
-    db.session.commit()
+    # --- Broadcast notification: per-user read receipt ---
+    if user_id is None:
+        # Cannot record a per-user read without knowing the user
+        return None
+
+    now = datetime.now(timezone.utc)
+    existing = NotificationRead.query.filter_by(
+        notification_id=notification_id,
+        user_id=user_id,
+    ).first()
+    if existing is None:
+        read_receipt = NotificationRead(
+            notification_id=notification_id,
+            user_id=user_id,
+            read_at=now,
+        )
+        db.session.add(read_receipt)
+        db.session.commit()
+
     return notification
 
 
 def mark_all_read(user_id):
     """Mark all unread notifications for a user as read.
 
-    Updates both user-targeted and broadcast notifications.
+    For **direct** notifications, bulk-updates ``is_read`` / ``read_at`` on
+    the notification rows.  For **broadcast** notifications, inserts
+    :class:`NotificationRead` rows for every broadcast that does not yet
+    have a read receipt for *user_id*.
 
     Args:
         user_id: The user ID whose notifications should be marked read.
 
     Returns:
-        The number of notifications that were updated.
+        The total number of notifications that were marked read (direct +
+        broadcast).
     """
     now = datetime.now(timezone.utc)
-    count = Notification.query.filter(
-        db.or_(
-            Notification.user_id == user_id,
-            Notification.user_id.is_(None),
-        ),
+
+    # --- Direct notifications ---
+    direct_count = Notification.query.filter(
+        Notification.user_id == user_id,
         Notification.is_read == False,  # noqa: E712
     ).update(
         {"is_read": True, "read_at": now},
         synchronize_session="fetch",
     )
+
+    # --- Broadcast notifications without a read receipt for this user ---
+    unread_broadcasts = (
+        Notification.query.outerjoin(
+            NotificationRead,
+            and_(
+                NotificationRead.notification_id == Notification.id,
+                NotificationRead.user_id == user_id,
+            ),
+        )
+        .filter(
+            Notification.user_id.is_(None),
+            NotificationRead.id.is_(None),
+        )
+        .all()
+    )
+    for broadcast in unread_broadcasts:
+        read_receipt = NotificationRead(
+            notification_id=broadcast.id,
+            user_id=user_id,
+            read_at=now,
+        )
+        db.session.add(read_receipt)
+
     db.session.commit()
-    return count
+    return direct_count + len(unread_broadcasts)
 
 
 # =========================================================================

--- a/migrations/versions/p0_2_notification_reads_table.py
+++ b/migrations/versions/p0_2_notification_reads_table.py
@@ -1,0 +1,47 @@
+"""P0-2: Add notification_reads table for per-user broadcast read tracking
+
+Broadcast notifications (user_id IS NULL) are shared rows.  This table
+stores per-user read receipts so that marking a broadcast as read for
+one user does not affect other users.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-08 01:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6a7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'notification_reads',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('notification_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('read_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['notification_id'], ['notifications.id'],
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['users.id'],
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint(
+            'notification_id', 'user_id',
+            name='uq_notification_user_read',
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table('notification_reads')

--- a/tests/unit/services/test_notification_service.py
+++ b/tests/unit/services/test_notification_service.py
@@ -15,6 +15,7 @@ from app.extensions import db
 from app.models.inventory import InventoryItem
 from app.models.invoice import Invoice
 from app.models.notification import Notification
+from app.models.notification_read import NotificationRead
 from app.models.payment import Payment
 from app.models.service_order import ServiceOrder
 from app.services import notification_service
@@ -424,3 +425,155 @@ class TestNotifyPaymentReceived:
         assert notif.notification_type == "payment_received"
         assert "INV-2026-90001" in notif.title
         assert "$100.00" in notif.message
+
+
+# =========================================================================
+# Per-user broadcast read state (P0-2)
+# =========================================================================
+
+
+class TestBroadcastPerUserReadState:
+    """Tests for per-user read tracking on broadcast notifications."""
+
+    def test_broadcast_mark_read_is_per_user(self, app, db_session):
+        """Marking a broadcast read for user A does not affect user B."""
+        user_a = _make_admin_user(
+            app, db_session, username="bcast_a", email="bcast_a@example.com"
+        )
+        user_b = _make_tech_user(
+            app, db_session, username="bcast_b", email="bcast_b@example.com"
+        )
+
+        broadcast = notification_service.create_notification(
+            user_id=None,
+            notification_type="system",
+            title="System-wide announcement",
+            message="Broadcast body",
+        )
+
+        # User A marks the broadcast as read
+        result = notification_service.mark_as_read(broadcast.id, user_id=user_a.id)
+        assert result is not None
+
+        # User A should see it as read (unread count = 0)
+        assert notification_service.get_unread_count(user_a.id) == 0
+
+        # User B should still see it as unread (unread count = 1)
+        assert notification_service.get_unread_count(user_b.id) == 1
+
+        # The Notification row itself should NOT have is_read flipped
+        db_session.refresh(broadcast)
+        assert broadcast.is_read is False
+
+    def test_mark_all_read_handles_broadcasts_per_user(self, app, db_session):
+        """mark_all_read for user A leaves broadcasts unread for user B."""
+        user_a = _make_admin_user(
+            app, db_session, username="mall_a", email="mall_a@example.com"
+        )
+        user_b = _make_tech_user(
+            app, db_session, username="mall_b", email="mall_b@example.com"
+        )
+
+        # One direct notification for each user and one broadcast
+        notification_service.create_notification(
+            user_id=user_a.id,
+            notification_type="system",
+            title="Direct for A",
+            message="msg",
+        )
+        notification_service.create_notification(
+            user_id=user_b.id,
+            notification_type="system",
+            title="Direct for B",
+            message="msg",
+        )
+        notification_service.create_notification(
+            user_id=None,
+            notification_type="system",
+            title="Broadcast",
+            message="msg",
+        )
+
+        # Before: A sees 2 unread (1 direct + 1 broadcast)
+        assert notification_service.get_unread_count(user_a.id) == 2
+        # Before: B sees 2 unread (1 direct + 1 broadcast)
+        assert notification_service.get_unread_count(user_b.id) == 2
+
+        # Mark all read for user A
+        marked = notification_service.mark_all_read(user_a.id)
+        assert marked == 2
+
+        # A now sees 0 unread
+        assert notification_service.get_unread_count(user_a.id) == 0
+
+        # B still sees 2 unread — the broadcast and their own direct notification
+        assert notification_service.get_unread_count(user_b.id) == 2
+
+    def test_unread_count_includes_unread_broadcasts(self, app, db_session):
+        """get_unread_count correctly sums direct + broadcast unread per user."""
+        user_a = _make_admin_user(
+            app, db_session, username="cnt_a", email="cnt_a@example.com"
+        )
+        user_b = _make_tech_user(
+            app, db_session, username="cnt_b", email="cnt_b@example.com"
+        )
+
+        # 2 direct for A, 1 broadcast
+        notification_service.create_notification(
+            user_id=user_a.id,
+            notification_type="system",
+            title="Direct A-1",
+            message="msg",
+        )
+        notification_service.create_notification(
+            user_id=user_a.id,
+            notification_type="system",
+            title="Direct A-2",
+            message="msg",
+        )
+        broadcast = notification_service.create_notification(
+            user_id=None,
+            notification_type="system",
+            title="Broadcast",
+            message="msg",
+        )
+
+        # A: 2 direct + 1 broadcast = 3
+        assert notification_service.get_unread_count(user_a.id) == 3
+        # B: 0 direct + 1 broadcast = 1
+        assert notification_service.get_unread_count(user_b.id) == 1
+
+        # Mark broadcast read for A only
+        notification_service.mark_as_read(broadcast.id, user_id=user_a.id)
+
+        # A: 2 direct + 0 broadcast = 2
+        assert notification_service.get_unread_count(user_a.id) == 2
+        # B: 0 direct + 1 broadcast = 1 (unchanged)
+        assert notification_service.get_unread_count(user_b.id) == 1
+
+    def test_broadcast_mark_read_idempotent(self, app, db_session):
+        """Marking the same broadcast read twice does not create duplicate rows."""
+        user = _make_admin_user(
+            app, db_session, username="idem_u", email="idem_u@example.com"
+        )
+
+        broadcast = notification_service.create_notification(
+            user_id=None,
+            notification_type="system",
+            title="Idempotent test",
+            message="msg",
+        )
+
+        # Mark read twice
+        notification_service.mark_as_read(broadcast.id, user_id=user.id)
+        notification_service.mark_as_read(broadcast.id, user_id=user.id)
+
+        # Should have exactly one NotificationRead row
+        read_count = NotificationRead.query.filter_by(
+            notification_id=broadcast.id,
+            user_id=user.id,
+        ).count()
+        assert read_count == 1
+
+        # Unread count should be 0
+        assert notification_service.get_unread_count(user.id) == 0


### PR DESCRIPTION
## Summary
- **P0-2 Critical**: Broadcast notifications (user_id=NULL) shared a single `is_read` flag. Any user marking a broadcast as read hid it for all users (IDOR-adjacent issue).
- Added `NotificationRead` model — per-user read receipts for broadcast notifications
- Rewrote `notification_service.py` to use `outerjoin` + `IS NULL` pattern for broadcast unread queries
- Direct (user-targeted) notifications still use the existing `is_read` field on the notification row
- Added Alembic migration `b2c3d4e5f6a7` creating `notification_reads` table

## Test plan
- [x] `test_broadcast_mark_read_is_per_user` — user A read doesn't affect user B
- [x] `test_mark_all_read_handles_broadcasts_per_user` — mark_all_read isolation
- [x] `test_unread_count_includes_unread_broadcasts` — correct sum of direct + broadcast
- [x] `test_broadcast_mark_read_idempotent` — no duplicate rows on repeated reads
- [x] Full suite: 766 tests passing