### PR TITLE
Enforce order status/priority validation and immutability (P0-3)

### DIFF
--- a/app/forms/order.py
+++ b/app/forms/order.py
@@ -64,11 +64,13 @@ class ServiceOrderForm(FlaskForm):
     status = SelectField(
         "Status",
         choices=[("", "-- Select --")] + VALID_STATUSES,
+        validators=[DataRequired()],
         default="intake",
     )
     priority = SelectField(
         "Priority",
         choices=[("", "-- Select --")] + VALID_PRIORITIES,
+        validators=[DataRequired()],
         default="normal",
     )
     assigned_tech_id = SelectField(

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -211,8 +211,6 @@ def update_order(order_id, data):
 
     for field in (
         "customer_id",
-        "status",
-        "priority",
         "assigned_tech_id",
         "date_received",
         "date_promised",
@@ -233,6 +231,12 @@ def update_order(order_id, data):
     ):
         if field in data:
             setattr(order, field, data[field])
+
+    # Priority requires explicit validation; status must go through change_status().
+    if "priority" in data:
+        valid_priorities = {"low", "normal", "high", "rush"}
+        if data["priority"] in valid_priorities:
+            order.priority = data["priority"]
 
     db.session.commit()
     return order
@@ -323,6 +327,10 @@ def change_status(order_id, new_status, user_id=None):
         transition was valid and applied, False otherwise.
     """
     order = get_order(order_id)
+
+    if not new_status:
+        return (order, False)
+
     current_status = order.status
 
     allowed = STATUS_TRANSITIONS.get(current_status, [])

--- a/tests/unit/forms/test_order_form.py
+++ b/tests/unit/forms/test_order_form.py
@@ -134,6 +134,38 @@ class TestServiceOrderFormInvalid:
             assert not form.validate()
             assert "estimated_total" in form.errors
 
+    def test_order_form_requires_status(self, app, db_session):
+        """Order form with blank status should fail validation."""
+        with app.test_request_context():
+            form = ServiceOrderForm(
+                formdata=MultiDict([
+                    ("customer_id", "1"),
+                    ("status", ""),
+                    ("priority", "normal"),
+                    ("date_received", date.today().isoformat()),
+                ])
+            )
+            form.customer_id.choices = [("", "-- Select --"), (1, "Test Customer")]
+            form.assigned_tech_id.choices = [("", "-- Select --")]
+            assert not form.validate()
+            assert "status" in form.errors
+
+    def test_order_form_requires_priority(self, app, db_session):
+        """Order form with blank priority should fail validation."""
+        with app.test_request_context():
+            form = ServiceOrderForm(
+                formdata=MultiDict([
+                    ("customer_id", "1"),
+                    ("status", "intake"),
+                    ("priority", ""),
+                    ("date_received", date.today().isoformat()),
+                ])
+            )
+            form.customer_id.choices = [("", "-- Select --"), (1, "Test Customer")]
+            form.assigned_tech_id.choices = [("", "-- Select --")]
+            assert not form.validate()
+            assert "priority" in form.errors
+
 
 # ---------------------------------------------------------------------------
 # ServiceOrderForm -- defaults

--- a/tests/unit/services/test_order_service.py
+++ b/tests/unit/services/test_order_service.py
@@ -290,6 +290,29 @@ class TestUpdateOrder:
         # Unchanged fields
         assert updated.status == "intake"
 
+    def test_update_order_cannot_change_status_directly(self, app, db_session):
+        """update_order() ignores status in the data dict; status must go through change_status()."""
+        order = _make_order(db_session, status="intake")
+
+        updated = order_service.update_order(
+            order.id,
+            {"status": "completed", "description": "Trying to skip workflow"},
+        )
+
+        assert updated.status == "intake"
+        assert updated.description == "Trying to skip workflow"
+
+    def test_update_order_rejects_invalid_priority(self, app, db_session):
+        """update_order() does not apply an invalid priority value."""
+        order = _make_order(db_session, priority="normal")
+
+        updated = order_service.update_order(
+            order.id,
+            {"priority": "ultra_urgent"},
+        )
+
+        assert updated.priority == "normal"
+
 
 # =========================================================================
 # delete_order
@@ -371,6 +394,24 @@ class TestChangeStatus:
         result_order, success = order_service.change_status(order.id, "intake")
 
         assert success is True
+        assert result_order.status == "intake"
+
+    def test_change_status_rejects_empty(self, app, db_session):
+        """change_status() with an empty string returns (order, False)."""
+        order = _make_order(db_session, status="intake")
+
+        result_order, success = order_service.change_status(order.id, "")
+
+        assert success is False
+        assert result_order.status == "intake"
+
+    def test_change_status_rejects_none(self, app, db_session):
+        """change_status() with None returns (order, False)."""
+        order = _make_order(db_session, status="intake")
+
+        result_order, success = order_service.change_status(order.id, None)
+
+        assert success is False
         assert result_order.status == "intake"
 
 


### PR DESCRIPTION
## Summary
- **P0-3**: `update_order()` allowed direct status changes, bypassing the `change_status()` workflow and its transition rules. This could lead to invalid state transitions.
- Removed `status` and `priority` from `update_order()` generic field loop
- Added explicit priority validation with allowlist (`low`, `normal`, `high`, `rush`)
- Added guard in `change_status()` to reject empty/None values
- Added `DataRequired()` validators to status and priority on `ServiceOrderForm`

## Test plan
- [x] `test_update_order_cannot_change_status_directly` — status in data dict is ignored
- [x] `test_update_order_rejects_invalid_priority` — invalid priority is ignored
- [x] `test_change_status_rejects_empty` — empty string returns (order, False)
- [x] `test_change_status_rejects_none` — None returns (order, False)
- [x] `test_order_form_requires_status` — blank status fails form validation
- [x] `test_order_form_requires_priority` — blank priority fails form validation
- [x] Full suite: 772 tests passing