### PR TITLE
Fix inventory forms to accept decimal quantities (P0-1)

### DIFF
--- a/app/blueprints/inventory.py
+++ b/app/blueprints/inventory.py
@@ -237,7 +237,7 @@ def adjust_stock(id):
         new_qty = item.quantity_in_stock + form.adjustment.data
         if new_qty < 0:
             flash(
-                f"Cannot adjust by {form.adjustment.data:+d}: "
+                f"Cannot adjust by {form.adjustment.data:+}: "
                 f"would result in negative stock ({new_qty}).",
                 "danger",
             )
@@ -245,7 +245,7 @@ def adjust_stock(id):
             item.quantity_in_stock = new_qty
             db.session.commit()
             flash(
-                f"Stock adjusted by {form.adjustment.data:+d}. "
+                f"Stock adjusted by {form.adjustment.data:+}. "
                 f"New quantity: {item.quantity_in_stock}.",
                 "success",
             )

--- a/app/forms/inventory.py
+++ b/app/forms/inventory.py
@@ -61,19 +61,21 @@ class InventoryItemForm(FlaskForm):
         places=2,
         validators=[Optional()],
     )
-    quantity_in_stock = IntegerField(
+    quantity_in_stock = DecimalField(
         "Quantity in Stock",
+        places=2,
         default=0,
-        validators=[Optional()],
+        validators=[Optional(), NumberRange(min=0)],
     )
-    reorder_level = IntegerField(
+    reorder_level = DecimalField(
         "Reorder Level",
+        places=2,
         default=0,
-        validators=[Optional()],
+        validators=[Optional(), NumberRange(min=0)],
     )
     reorder_quantity = IntegerField(
         "Reorder Quantity",
-        validators=[Optional()],
+        validators=[Optional(), NumberRange(min=0)],
     )
     unit_of_measure = SelectField(
         "Unit of Measure",
@@ -145,11 +147,13 @@ class StockAdjustmentForm(FlaskForm):
     """Form for adjusting the stock level of an inventory item.
 
     The ``adjustment`` value can be positive (stock in) or negative
-    (stock out / correction).
+    (stock out / correction).  Supports decimal quantities for
+    fractional units (e.g., 2.5 ft of tape).
     """
 
-    adjustment = IntegerField(
+    adjustment = DecimalField(
         "Adjustment (+/-)",
+        places=2,
         validators=[DataRequired()],
     )
     reason = StringField(

--- a/tests/blueprint/test_inventory_routes.py
+++ b/tests/blueprint/test_inventory_routes.py
@@ -336,6 +336,68 @@ class TestTechnicianCRUD:
             item = db.session.get(InventoryItem, item_id)
             assert item.quantity_in_stock == 7
 
+    def test_create_with_decimal_quantity(self, logged_in_client, app, db_session):
+        """Decimal quantity_in_stock and reorder_level are accepted."""
+        from decimal import Decimal
+        response = logged_in_client.post(
+            "/inventory/new",
+            data={
+                "name": "Neoprene Tape",
+                "category": "Adhesives",
+                "sku": "TAPE-001",
+                "quantity_in_stock": "12.50",
+                "reorder_level": "3.25",
+                "unit_of_measure": "ft",
+                "is_active": "y",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+        with app.app_context():
+            item = InventoryItem.query.filter_by(name="Neoprene Tape").first()
+            assert item is not None
+            assert item.quantity_in_stock == Decimal("12.50")
+            assert item.reorder_level == Decimal("3.25")
+
+    def test_adjust_stock_decimal(self, logged_in_client, app, db_session):
+        """Decimal stock adjustments work correctly."""
+        from decimal import Decimal
+        with app.app_context():
+            item = _create_inventory_item(
+                db_session, quantity_in_stock=10, sku="DEC-ADJ-001"
+            )
+            item_id = item.id
+        response = logged_in_client.post(
+            f"/inventory/{item_id}/adjust",
+            data={"adjustment": "2.5", "reason": "Partial restock"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+        with app.app_context():
+            item = db.session.get(InventoryItem, item_id)
+            assert item.quantity_in_stock == Decimal("12.50")
+
+    def test_adjust_stock_negative_decimal(self, logged_in_client, app, db_session):
+        """Negative decimal adjustments deduct fractional quantities."""
+        from decimal import Decimal
+        with app.app_context():
+            item = _create_inventory_item(
+                db_session, quantity_in_stock=10, sku="DEC-NEG-001"
+            )
+            item_id = item.id
+        response = logged_in_client.post(
+            f"/inventory/{item_id}/adjust",
+            data={"adjustment": "-1.75", "reason": "Used partial"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+        with app.app_context():
+            item = db.session.get(InventoryItem, item_id)
+            assert item.quantity_in_stock == Decimal("8.25")
+
     def test_adjust_stock_deleted_returns_404(
         self, logged_in_client, app, db_session
     ):

--- a/tests/unit/forms/test_inventory_form.py
+++ b/tests/unit/forms/test_inventory_form.py
@@ -67,6 +67,37 @@ class TestInventoryItemFormValid:
             )
             assert form.validate(), form.errors
 
+    def test_valid_decimal_quantities(self, app):
+        """Decimal values accepted for quantity_in_stock and reorder_level."""
+        with app.test_request_context():
+            form = InventoryItemForm(
+                formdata=MultiDict([
+                    ("name", "Neoprene Tape"),
+                    ("category", "Adhesives"),
+                    ("unit_of_measure", "ft"),
+                    ("quantity_in_stock", "12.50"),
+                    ("reorder_level", "3.25"),
+                ])
+            )
+            assert form.validate(), form.errors
+            from decimal import Decimal
+            assert form.quantity_in_stock.data == Decimal("12.50")
+            assert form.reorder_level.data == Decimal("3.25")
+
+    def test_negative_quantity_rejected(self, app):
+        """Negative quantity_in_stock should fail validation."""
+        with app.test_request_context():
+            form = InventoryItemForm(
+                formdata=MultiDict([
+                    ("name", "Bad Item"),
+                    ("category", "Parts"),
+                    ("unit_of_measure", "each"),
+                    ("quantity_in_stock", "-5"),
+                ])
+            )
+            assert not form.validate()
+            assert "quantity_in_stock" in form.errors
+
 
 # ---------------------------------------------------------------------------
 # InventoryItemForm — invalid data
@@ -189,6 +220,28 @@ class TestStockAdjustmentForm:
                 formdata=MultiDict([
                     ("adjustment", "-5"),
                     ("reason", "Used in repair"),
+                ])
+            )
+            assert form.validate(), form.errors
+
+    def test_valid_decimal_adjustment(self, app):
+        """Decimal adjustments are accepted (e.g., 2.5 ft of tape)."""
+        with app.test_request_context():
+            form = StockAdjustmentForm(
+                formdata=MultiDict([
+                    ("adjustment", "2.5"),
+                    ("reason", "Partial roll received"),
+                ])
+            )
+            assert form.validate(), form.errors
+
+    def test_valid_negative_decimal_adjustment(self, app):
+        """Negative decimal adjustments are accepted."""
+        with app.test_request_context():
+            form = StockAdjustmentForm(
+                formdata=MultiDict([
+                    ("adjustment", "-0.75"),
+                    ("reason", "Used partial unit"),
                 ])
             )
             assert form.validate(), form.errors


### PR DESCRIPTION
## Summary
- Fixes CODEX review P0-1: inventory form `IntegerField` truncated decimal quantities, causing stock drift between billed and deducted amounts
- Changes `quantity_in_stock`, `reorder_level`, and `StockAdjustmentForm.adjustment` from `IntegerField` to `DecimalField(places=2)`
- Adds `NumberRange(min=0)` validators on stock fields to prevent negative input

## Test plan
- [x] 7 new tests: decimal create, decimal adjustment (+/-), negative quantity rejection, decimal form validation
- [x] All 809 tests pass (802 existing + 7 new)
- [x] No regressions in full test suite