### PR TITLE
Prevent negative stock in add_part_used() (P0-2)

### DIFF
--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -591,10 +591,21 @@ def add_part_used(
 
     Returns:
         The newly created PartUsed instance.
+
+    Raises:
+        ValueError: If inventory item not found or insufficient stock.
     """
     inv_item = db.session.get(InventoryItem, inventory_item_id)
     if inv_item is None:
         raise ValueError(f"Inventory item {inventory_item_id} not found.")
+
+    # Prevent deductions that would drive stock negative
+    new_stock = inv_item.quantity_in_stock - quantity
+    if new_stock < 0:
+        raise ValueError(
+            f"Insufficient stock for '{inv_item.name}': "
+            f"have {inv_item.quantity_in_stock}, need {quantity}."
+        )
 
     # Snapshot cost from inventory
     unit_cost = inv_item.purchase_cost if inv_item.purchase_cost is not None else Decimal("0.00")
@@ -616,8 +627,8 @@ def add_part_used(
     )
     db.session.add(part)
 
-    # Deduct from inventory stock
-    inv_item.quantity_in_stock -= quantity
+    # Deduct from inventory stock (already validated non-negative above)
+    inv_item.quantity_in_stock = new_stock
 
     # Only commit if this is a standalone call (not nested inside
     # add_applied_service which manages its own commit).

--- a/tests/unit/services/test_order_service.py
+++ b/tests/unit/services/test_order_service.py
@@ -538,6 +538,49 @@ class TestPartsUsed:
         db_session.refresh(inv)
         assert inv.quantity_in_stock == Decimal("7.25")
 
+    def test_add_part_used_rejects_negative_stock(self, app, db_session):
+        """add_part_used() raises ValueError when deduction exceeds stock."""
+        order = _make_order(db_session)
+        si = _make_service_item(db_session)
+        oi = _make_order_item(db_session, order=order, service_item=si)
+        inv = _make_inventory_item(
+            db_session,
+            sku="SKU-NEG-GUARD",
+            quantity_in_stock=Decimal("3.00"),
+        )
+
+        with pytest.raises(ValueError, match="Insufficient stock"):
+            order_service.add_part_used(
+                order_item_id=oi.id,
+                inventory_item_id=inv.id,
+                quantity=Decimal("5.00"),
+            )
+
+        # Stock should be unchanged
+        db_session.refresh(inv)
+        assert inv.quantity_in_stock == Decimal("3.00")
+
+    def test_add_part_used_allows_exact_depletion(self, app, db_session):
+        """Deducting exactly all remaining stock should succeed (stock → 0)."""
+        order = _make_order(db_session)
+        si = _make_service_item(db_session)
+        oi = _make_order_item(db_session, order=order, service_item=si)
+        inv = _make_inventory_item(
+            db_session,
+            sku="SKU-EXACT-DEPLETE",
+            quantity_in_stock=Decimal("5.00"),
+        )
+
+        part = order_service.add_part_used(
+            order_item_id=oi.id,
+            inventory_item_id=inv.id,
+            quantity=Decimal("5.00"),
+        )
+
+        assert part.id is not None
+        db_session.refresh(inv)
+        assert inv.quantity_in_stock == Decimal("0.00")
+
 
 # =========================================================================
 # Labor Entries


### PR DESCRIPTION
## Summary
- Fixes CODEX review P0-2: `add_part_used()` could drive inventory stock negative with no guard
- Adds pre-deduction validation that raises `ValueError` when quantity exceeds available stock
- Route handler already catches `ValueError` and flashes the message to the user

## Test plan
- [x] New test: over-deduction raises ValueError with "Insufficient stock" message
- [x] New test: exact depletion to zero succeeds
- [x] All 804 tests pass (802 existing + 2 new)