### PR TITLE
Make entrypoint fail-fast in production mode (P1-2)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,15 +5,25 @@ set -e
 # not for celery workers or beat schedulers.
 if [[ "$1" == "gunicorn" ]]; then
     echo "Running database migrations..."
-    flask db upgrade 2>&1 || {
-        echo "WARNING: Database migration failed. The app may not work correctly."
-        echo "Check the migration history and database state."
-    }
+    if ! flask db upgrade 2>&1; then
+        if [[ "$DSM_ENV" == "production" ]]; then
+            echo "FATAL: Database migration failed in production. Refusing to start."
+            exit 1
+        else
+            echo "WARNING: Database migration failed. The app may not work correctly."
+            echo "Check the migration history and database state."
+        fi
+    fi
 
     echo "Seeding database defaults..."
-    flask seed-db 2>&1 || {
-        echo "WARNING: Database seeding failed. Roles or defaults may be missing."
-    }
+    if ! flask seed-db 2>&1; then
+        if [[ "$DSM_ENV" == "production" ]]; then
+            echo "FATAL: Database seeding failed in production. Refusing to start."
+            exit 1
+        else
+            echo "WARNING: Database seeding failed. Roles or defaults may be missing."
+        fi
+    fi
 fi
 
 echo "Starting: $@"


### PR DESCRIPTION
## Summary
- Fixes CODEX review P1-2: migration/seeding failures were non-fatal warnings even in production
- When `DSM_ENV=production`, migration or seeding failures now exit 1 to prevent serving with incompatible schema
- Dev/testing environments keep the existing warning-only behavior

## Test plan
- [x] Manual verification: entrypoint exits on failure with `DSM_ENV=production`
- [x] Manual verification: entrypoint warns but continues with `DSM_ENV=development`