### PR TITLE
Fix tax rate display to show correct percentage (P1-3)

### DIFF
--- a/app/templates/invoices/detail.html
+++ b/app/templates/invoices/detail.html
@@ -157,7 +157,7 @@
           <dt class="col-7">Subtotal</dt>
           <dd class="col-5 text-end">${{ "%.2f"|format(invoice.subtotal) }}</dd>
           {% if invoice.tax_amount is not none and invoice.tax_amount > 0 %}
-          <dt class="col-7">Tax ({{ "%.2f"|format(invoice.tax_rate) }}%)</dt>
+          <dt class="col-7">Tax ({{ "%.2f"|format(invoice.tax_rate * 100) }}%)</dt>
           <dd class="col-5 text-end">${{ "%.2f"|format(invoice.tax_amount) }}</dd>
           {% endif %}
           {% if invoice.discount_amount is not none and invoice.discount_amount > 0 %}

--- a/app/templates/invoices/form.html
+++ b/app/templates/invoices/form.html
@@ -74,7 +74,7 @@
     <div class="card-body">
       <div class="row">
         <div class="col-md-6">
-          {{ render_field(form.tax_rate, placeholder='0.00') }}
+          {{ render_field(form.tax_rate, placeholder='0.0825', help_text='Decimal fraction, e.g. 0.0825 = 8.25%') }}
         </div>
         <div class="col-md-6">
           {{ render_field(form.discount_amount, placeholder='0.00') }}

--- a/tests/blueprint/test_invoice_routes.py
+++ b/tests/blueprint/test_invoice_routes.py
@@ -307,6 +307,21 @@ class TestAdminCRUD:
             # Status is not changed via edit — use change_status route
             assert updated.status == "draft"
 
+    def test_tax_rate_displays_as_percentage(self, admin_client, app, db_session):
+        """Tax rate stored as 0.0825 should display as '8.25%' on detail page."""
+        with app.app_context():
+            invoice = _create_invoice(
+                db_session,
+                tax_rate=Decimal("0.0825"),
+                tax_amount=Decimal("8.25"),
+                total=Decimal("108.25"),
+                balance_due=Decimal("108.25"),
+            )
+            inv_id = invoice.id
+        response = admin_client.get(f"/invoices/{inv_id}")
+        assert response.status_code == 200
+        assert b"8.25%" in response.data
+
     def test_admin_can_void_invoice(self, admin_client, app, db_session):
         with app.app_context():
             invoice = _create_invoice(db_session, status="sent")


### PR DESCRIPTION
## Summary
- Fixes CODEX review P1-3: tax rate stored as decimal fraction (0.0825) displayed as "0.08%" instead of "8.25%"
- Invoice detail template now multiplies by 100 before displaying with % sign
- Form placeholder updated with help text: "Decimal fraction, e.g. 0.0825 = 8.25%"

## Test plan
- [x] New test: invoice with tax_rate=0.0825 displays "8.25%" on detail page
- [x] All 803 tests pass