### PR TITLE
Remove misleading status fields from edit forms (P1-4)

### DIFF
--- a/app/blueprints/orders.py
+++ b/app/blueprints/orders.py
@@ -255,9 +255,9 @@ def edit(id):
     _populate_order_form_choices(form)
 
     if form.validate_on_submit():
+        # Status is not included here — use the change_status route instead.
         data = {
             "customer_id": form.customer_id.data,
-            "status": form.status.data,
             "priority": form.priority.data,
             "assigned_tech_id": form.assigned_tech_id.data,
             "date_received": form.date_received.data,

--- a/app/templates/invoices/form.html
+++ b/app/templates/invoices/form.html
@@ -35,15 +35,16 @@
           {{ render_select(form.customer_id) }}
         </div>
         <div class="col-md-6">
-          {% if is_edit %}
-          {{ render_select(form.status) }}
-          {% else %}
           <div class="mb-3">
             <label class="form-label">Status</label>
+            {% if is_edit %}
+            <input type="text" class="form-control" value="{{ invoice.status|replace('_', ' ')|title }}" disabled>
+            <div class="form-text">Use the status buttons on the invoice detail page to change status.</div>
+            {% else %}
             <input type="text" class="form-control" value="Draft" disabled>
             <div class="form-text">New invoices start in Draft status.</div>
+            {% endif %}
           </div>
-          {% endif %}
         </div>
       </div>
     </div>

--- a/app/templates/orders/form.html
+++ b/app/templates/orders/form.html
@@ -58,32 +58,28 @@
     </div>
   </div>
 
-  {# Status & Priority (edit only for status) #}
+  {# Status & Priority #}
   <div class="card mb-4">
     <div class="card-header">
       <h5 class="card-title mb-0">Status & Priority</h5>
     </div>
     <div class="card-body">
       <div class="row">
-        {% if is_edit %}
-        <div class="col-md-6">
-          {{ render_select(form.status) }}
-        </div>
-        <div class="col-md-6">
-          {{ render_select(form.priority) }}
-        </div>
-        {% else %}
         <div class="col-md-6">
           {{ render_select(form.priority) }}
         </div>
         <div class="col-md-6">
           <div class="mb-3">
             <label class="form-label">Status</label>
+            {% if is_edit %}
+            <input type="text" class="form-control" value="{{ order.status|replace('_', ' ')|title }}" disabled>
+            <div class="form-text">Use the status buttons on the order detail page to change status.</div>
+            {% else %}
             <input type="text" class="form-control" value="Intake" disabled>
             <div class="form-text">New orders start in Intake status.</div>
+            {% endif %}
           </div>
         </div>
-        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Fixes CODEX review P1-4: order and invoice edit forms showed editable status dropdowns that were silently ignored
- Both forms now show status as read-only text with help text directing users to the detail page for status changes
- Cleaned up the order edit route to not pass status to update_order

## Test plan
- [x] All 802 tests pass
- [x] Visual verification: edit forms show read-only status with guidance text