### PR TITLE
Fix Celery Beat healthcheck to use schedule file age

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
     networks:
       - dsm-net
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' > /dev/null"]
+      test: ["CMD-SHELL", "test -f /tmp/celerybeat-schedule && find /tmp/celerybeat-schedule -mmin -3 | grep -q ."]
       interval: 60s
       timeout: 5s
       start_period: 15s


### PR DESCRIPTION
## Summary
- Replace `pgrep -f 'celery.*beat'` healthcheck with schedule file age verification
- New check: `test -f /tmp/celerybeat-schedule && find /tmp/celerybeat-schedule -mmin -3`
- More reliable: detects stalled beat processes (not just running PIDs)

## Test plan
- [ ] `docker compose up` and verify beat container becomes healthy
- [ ] Stop beat process inside container → healthcheck should fail within 3 min
- [ ] `docker compose ps` shows beat as healthy under normal operation