### PR TITLE
Fix #25: Add Service Items to sidebar navigation

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -198,6 +198,14 @@
           </a>
         </li>
         <li class="nav-item">
+          <a class="nav-link {{ 'active' if request.endpoint and request.endpoint.startswith('items') }}"
+             href="{{ url_for('items.list_items') }}"
+             title="Service Items">
+            <i class="bi bi-wrench"></i>
+            <span class="nav-text">Service Items</span>
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link {{ 'active' if request.endpoint and request.endpoint.startswith('orders') }}"
              href="{{ url_for('orders.list_orders') }}"
              title="Orders">


### PR DESCRIPTION
## Summary
- Add Service Items link (wrench icon) to sidebar between Customers and Orders
- Active state highlighting follows existing nav pattern
- Closes #25

## Test plan
- [x] Verify Service Items appears in sidebar on all pages
- [x] Active highlighting works when on items pages