### PR TITLE
Fix camera/photo upload issues (#26, #27, #28)

### DIFF
--- a/app/templates/orders/detail.html
+++ b/app/templates/orders/detail.html
@@ -908,6 +908,7 @@ function handleFileSelect(input, type, id) {
         previewImg.classList.add('d-none');
     }
     previewArea.classList.remove('d-none');
+    previewArea.scrollIntoView({ behavior: 'smooth' });
     hideError(type, id);
     input.value = '';
 }

--- a/app/templates/partials/image_capture.html
+++ b/app/templates/partials/image_capture.html
@@ -152,6 +152,7 @@ function handleFileSelect(input, type, id) {
     }
 
     previewArea.classList.remove('d-none');
+    previewArea.scrollIntoView({ behavior: 'smooth' });
     hideError(type, id);
 
     // Reset the input so the same file can be selected again


### PR DESCRIPTION
## Summary
- **Fix #28**: Resolve JS ReferenceError caused by `const pendingFiles` Temporal Dead Zone — changed to `window.pendingFiles`
- **Fix #27**: Add upload status spinner with "Uploading..." feedback when preview is bypassed
- **Fix #26**: Auto-scroll to upload preview area on mobile after photo capture

## Test plan
- [x] Order blueprint tests pass
- [ ] Manual: Take photo on mobile → preview scrolls into view
- [ ] Manual: Upload file → spinner shows during upload
- [ ] Manual: Photo upload preview box appears (was broken by #28)

Closes #26, #27, #28