### PR TITLE
Add in-app documentation access via /docs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -130,6 +130,7 @@ def _register_blueprints(app):
     from app.blueprints.auth import auth_bp
     from app.blueprints.customers import customers_bp
     from app.blueprints.dashboard import dashboard_bp
+    from app.blueprints.docs import docs_bp
     from app.blueprints.export import export_bp
     from app.blueprints.health import health_bp
     from app.blueprints.inventory import inventory_bp
@@ -147,6 +148,7 @@ def _register_blueprints(app):
     app.register_blueprint(auth_bp)
     app.register_blueprint(customers_bp)
     app.register_blueprint(dashboard_bp)
+    app.register_blueprint(docs_bp)
     app.register_blueprint(export_bp)
     app.register_blueprint(health_bp)
     app.register_blueprint(inventory_bp)

--- a/app/blueprints/docs.py
+++ b/app/blueprints/docs.py
@@ -1,0 +1,86 @@
+"""Documentation blueprint — serves project docs as rendered HTML.
+
+Reads markdown files from the ``docs/`` directory and renders them
+with the ``markdown`` library.  All routes require authentication.
+"""
+
+import os
+import re
+
+import markdown
+from flask import Blueprint, abort, current_app, render_template
+from flask_security import login_required
+
+docs_bp = Blueprint("docs", __name__, url_prefix="/docs")
+
+# Mapping of URL slugs to markdown filenames
+_DOC_FILES = {
+    "user-guide": "user_guide.md",
+    "architecture": "architecture.md",
+    "installation": "installation.md",
+    "configuration": "configuration.md",
+    "cloud-deployment": "cloud_deployment.md",
+}
+
+
+def _docs_dir():
+    """Return the absolute path to the docs/ directory."""
+    return os.path.join(current_app.root_path, "..", "docs")
+
+
+def _extract_title(md_content):
+    """Extract the first ``# heading`` from markdown content."""
+    match = re.search(r"^#\s+(.+)$", md_content, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def _get_doc_list():
+    """Return a list of dicts with slug, title, and filename for each doc."""
+    docs = []
+    docs_path = _docs_dir()
+    for slug, filename in sorted(_DOC_FILES.items()):
+        filepath = os.path.join(docs_path, filename)
+        if not os.path.isfile(filepath):
+            continue
+        with open(filepath, "r", encoding="utf-8") as f:
+            first_lines = f.read(500)
+        title = _extract_title(first_lines) or slug.replace("-", " ").title()
+        docs.append({"slug": slug, "title": title, "filename": filename})
+    return docs
+
+
+@docs_bp.route("/")
+@login_required
+def index():
+    """List available documentation pages."""
+    return render_template("docs/index.html", docs=_get_doc_list())
+
+
+@docs_bp.route("/<slug>")
+@login_required
+def detail(slug):
+    """Render a single documentation page."""
+    filename = _DOC_FILES.get(slug)
+    if filename is None:
+        abort(404)
+
+    filepath = os.path.join(_docs_dir(), filename)
+    if not os.path.isfile(filepath):
+        abort(404)
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        md_content = f.read()
+
+    title = _extract_title(md_content) or slug.replace("-", " ").title()
+    html_content = markdown.markdown(
+        md_content,
+        extensions=["fenced_code", "tables", "toc", "codehilite"],
+    )
+
+    return render_template(
+        "docs/detail.html",
+        title=title,
+        content=html_content,
+        docs=_get_doc_list(),
+        current_slug=slug,
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -254,6 +254,15 @@
           </a>
         </li>
 
+        <li class="nav-item">
+          <a class="nav-link {{ 'active' if request.endpoint and request.endpoint.startswith('docs') }}"
+             href="{{ url_for('docs.index') }}"
+             title="Documentation">
+            <i class="bi bi-book"></i>
+            <span class="nav-text">Documentation</span>
+          </a>
+        </li>
+
         {# Admin section - restricted to admin role #}
         {% if current_user.is_authenticated and current_user.has_role('admin') %}
         <li class="nav-item mt-2">

--- a/app/templates/docs/detail.html
+++ b/app/templates/docs/detail.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }} - Documentation - Dive Service Management{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ url_for('docs.index') }}">Documentation</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ title }}</li>
+      </ol>
+    </nav>
+  </div>
+</div>
+
+<div class="row">
+  {# Sidebar: doc navigation #}
+  <div class="col-md-3 mb-4">
+    <div class="card">
+      <div class="card-header">
+        <h6 class="card-title mb-0"><i class="bi bi-list-ul me-1"></i> Documents</h6>
+      </div>
+      <div class="list-group list-group-flush">
+        {% for doc in docs %}
+        <a href="{{ url_for('docs.detail', slug=doc.slug) }}"
+           class="list-group-item list-group-item-action {{ 'active' if doc.slug == current_slug else '' }}">
+          {{ doc.title }}
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  {# Main content #}
+  <div class="col-md-9">
+    <div class="card">
+      <div class="card-body markdown-body">
+        {{ content|safe }}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/docs/index.html
+++ b/app/templates/docs/index.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block title %}Documentation - Dive Service Management{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-0">Documentation</h1>
+    <small class="text-muted">{{ docs|length }} document{{ 's' if docs|length != 1 else '' }} available</small>
+  </div>
+</div>
+
+<div class="row g-3">
+  {% for doc in docs %}
+  <div class="col-md-6 col-lg-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <h5 class="card-title">
+          <i class="bi bi-file-earmark-text me-2 text-primary"></i>
+          {{ doc.title }}
+        </h5>
+        <p class="card-text text-muted small">{{ doc.filename }}</p>
+      </div>
+      <div class="card-footer bg-transparent">
+        <a href="{{ url_for('docs.detail', slug=doc.slug) }}" class="btn btn-sm btn-outline-primary">
+          <i class="bi bi-book me-1"></i> Read
+        </a>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{% if not docs %}
+<div class="card">
+  <div class="card-body text-center py-5">
+    <i class="bi bi-file-earmark-x fs-1 text-muted mb-3 d-block"></i>
+    <h5 class="text-muted">No documentation found</h5>
+    <p class="text-muted mb-0">Documentation files should be placed in the <code>docs/</code> directory.</p>
+  </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,5 +45,8 @@ gunicorn==22.0.0
 # Mail (optional, for future notification emails)
 Flask-Mail==0.10.0
 
+# Documentation rendering
+Markdown==3.10.2
+
 # CLI
 click==8.1.7

--- a/tests/test_blueprints/test_docs.py
+++ b/tests/test_blueprints/test_docs.py
@@ -1,0 +1,74 @@
+"""Tests for the in-app documentation blueprint."""
+
+import pytest
+
+
+class TestDocsIndex:
+    """Tests for GET /docs."""
+
+    def test_docs_index_requires_auth(self, client):
+        """Unauthenticated users are redirected to login."""
+        resp = client.get("/docs/")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers.get("Location", "")
+
+    def test_docs_index_renders(self, logged_in_client):
+        """Authenticated users see the docs index page."""
+        resp = logged_in_client.get("/docs/")
+        assert resp.status_code == 200
+        assert b"Documentation" in resp.data
+
+    def test_docs_index_lists_documents(self, logged_in_client):
+        """The index page lists available documentation files."""
+        resp = logged_in_client.get("/docs/")
+        assert resp.status_code == 200
+        # Should contain links to at least the user guide
+        assert b"user-guide" in resp.data
+
+
+class TestDocsDetail:
+    """Tests for GET /docs/<slug>."""
+
+    def test_docs_detail_requires_auth(self, client):
+        """Unauthenticated users are redirected to login."""
+        resp = client.get("/docs/user-guide")
+        assert resp.status_code == 302
+
+    def test_docs_detail_renders_user_guide(self, logged_in_client):
+        """The user guide renders as HTML."""
+        resp = logged_in_client.get("/docs/user-guide")
+        assert resp.status_code == 200
+        assert b"User Guide" in resp.data or b"user guide" in resp.data.lower()
+
+    def test_docs_detail_renders_architecture(self, logged_in_client):
+        """The architecture doc renders as HTML."""
+        resp = logged_in_client.get("/docs/architecture")
+        assert resp.status_code == 200
+
+    def test_docs_detail_404_for_unknown_slug(self, logged_in_client):
+        """Unknown slugs return 404."""
+        resp = logged_in_client.get("/docs/nonexistent-doc")
+        assert resp.status_code == 404
+
+    def test_docs_detail_has_sidebar_nav(self, logged_in_client):
+        """The detail page includes a sidebar with doc navigation."""
+        resp = logged_in_client.get("/docs/user-guide")
+        assert resp.status_code == 200
+        assert b"Documents" in resp.data
+
+    def test_docs_detail_has_breadcrumb(self, logged_in_client):
+        """The detail page includes a breadcrumb back to docs index."""
+        resp = logged_in_client.get("/docs/configuration")
+        assert resp.status_code == 200
+        assert b"breadcrumb" in resp.data
+
+
+class TestDocsNavLink:
+    """Test that the docs link appears in the sidebar."""
+
+    def test_sidebar_has_docs_link(self, logged_in_client):
+        """The main sidebar includes a Documentation link."""
+        resp = logged_in_client.get("/")
+        assert resp.status_code in (200, 302)
+        if resp.status_code == 200:
+            assert b"Documentation" in resp.data


### PR DESCRIPTION
## Summary
- New `/docs` blueprint renders project markdown files (user guide, architecture, config, installation, cloud deployment) as styled HTML
- Index page at `/docs/` lists all documents with titles extracted from `# headings`
- Detail pages with sidebar navigation and breadcrumbs
- Markdown rendered with fenced_code, tables, toc extensions
- "Documentation" link added to sidebar (book icon)
- All routes require authentication

## Test plan
- [x] 10 blueprint tests (auth, rendering, 404, nav links, breadcrumbs)
- [ ] Visit /docs → see document list
- [ ] Click any doc → rendered HTML with sidebar nav