### PR TITLE
Add unified photo gallery for service item detail (#44)

### DIFF
--- a/app/blueprints/attachments.py
+++ b/app/blueprints/attachments.py
@@ -196,3 +196,23 @@ def gallery(attachable_type, attachable_id):
         attachable_id=attachable_id,
         can_edit=can_edit,
     )
+
+
+@attachments_bp.route("/gallery/unified/<int:service_item_id>")
+@login_required
+def unified_gallery(service_item_id):
+    """Return an HTML fragment with the unified photo history for a service item.
+
+    Combines direct item attachments with photos from all service order
+    items referencing this equipment.  Designed to be loaded via hx-get.
+    """
+    direct, order_attachments = attachment_service.get_unified_attachments(
+        service_item_id
+    )
+
+    return render_template(
+        "partials/unified_gallery.html",
+        direct_attachments=direct,
+        order_attachments=order_attachments,
+        service_item_id=service_item_id,
+    )

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -14,6 +14,7 @@ from werkzeug.utils import secure_filename
 
 from app.extensions import db
 from app.models.attachment import Attachment
+from app.models.service_order_item import ServiceOrderItem
 
 # Allowed MIME types for upload
 ALLOWED_MIME_TYPES = {
@@ -207,6 +208,56 @@ def delete_attachment(attachment_id):
     db.session.delete(attachment)
     db.session.commit()
     return True
+
+
+def get_unified_attachments(service_item_id):
+    """Return all attachments for a service item and its service order items.
+
+    Provides a complete visual history by combining direct item photos
+    with photos taken during service visits.
+
+    Args:
+        service_item_id: ID of the ServiceItem.
+
+    Returns:
+        tuple: (direct_attachments, order_attachments) where
+            direct_attachments is a list of Attachment objects for the item,
+            order_attachments is a list of dicts with keys 'order_item',
+            'order', and 'attachments' for each service order item that
+            has attachments.
+    """
+    # Direct attachments on the service item
+    direct = (
+        Attachment.query
+        .filter_by(attachable_type="service_item", attachable_id=service_item_id)
+        .order_by(Attachment.created_at.desc())
+        .all()
+    )
+
+    # Find all service order items referencing this equipment
+    order_items = (
+        ServiceOrderItem.query
+        .filter_by(service_item_id=service_item_id)
+        .all()
+    )
+
+    # Collect attachments for each order item that has any
+    order_attachments = []
+    for oi in order_items:
+        atts = (
+            Attachment.query
+            .filter_by(attachable_type="service_order_item", attachable_id=oi.id)
+            .order_by(Attachment.created_at.desc())
+            .all()
+        )
+        if atts:
+            order_attachments.append({
+                "order_item": oi,
+                "order": oi.order,
+                "attachments": atts,
+            })
+
+    return direct, order_attachments
 
 
 def get_attachment_path(attachment):

--- a/app/templates/items/detail.html
+++ b/app/templates/items/detail.html
@@ -102,6 +102,25 @@
 {% set capture_title = 'Images' %}
 {% include 'partials/image_capture.html' with context %}
 
+{# Complete Photo History (direct + service visit photos) #}
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title mb-0"><i class="bi bi-images me-2"></i>Complete Photo History</h5>
+  </div>
+  <div class="card-body">
+    <div id="unified-gallery-{{ item.id }}"
+         hx-get="{{ url_for('attachments.unified_gallery', service_item_id=item.id) }}"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+      <div class="text-center py-2">
+        <div class="spinner-border spinner-border-sm text-muted" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 {# Notes #}
 {% if item.notes %}
 <div class="card mb-4">

--- a/app/templates/partials/unified_gallery.html
+++ b/app/templates/partials/unified_gallery.html
@@ -1,0 +1,96 @@
+{# Unified gallery fragment — shows combined photo history for a service item.
+
+   Loaded via HTMX into the item detail page.  Displays two sections:
+   1. Item Photos — direct attachments on the service item
+   2. Service Visit Photos — attachments from service order items, grouped by order
+#}
+
+{# --- Item Photos --- #}
+<h6 class="fw-semibold mb-2"><i class="bi bi-camera me-1"></i>Item Photos</h6>
+{% if direct_attachments %}
+<div class="row g-2 mb-4">
+  {% for att in direct_attachments %}
+  <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+    <div class="card h-100">
+      <a href="{{ url_for('attachments.serve_file', id=att.id) }}" target="_blank"
+         class="text-decoration-none">
+        {% if att.is_image %}
+        <img src="{{ url_for('attachments.thumbnail', id=att.id) }}"
+             class="card-img-top"
+             alt="{{ att.filename }}"
+             style="height: 120px; object-fit: cover;"
+             loading="lazy">
+        {% else %}
+        <div class="card-img-top d-flex align-items-center justify-content-center bg-light"
+             style="height: 120px;">
+          <i class="bi bi-file-earmark-pdf text-danger" style="font-size: 2.5rem;"></i>
+        </div>
+        {% endif %}
+      </a>
+      <div class="card-body p-2">
+        <p class="card-text small text-truncate mb-0" title="{{ att.filename }}">
+          {{ att.filename }}
+        </p>
+        {% if att.description %}
+        <p class="card-text small text-muted text-truncate mb-0" title="{{ att.description }}">
+          {{ att.description }}
+        </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-muted small mb-3">No item photos.</p>
+{% endif %}
+
+{# --- Service Visit Photos --- #}
+<h6 class="fw-semibold mb-2"><i class="bi bi-clock-history me-1"></i>Service Visit Photos</h6>
+{% if order_attachments %}
+{% for group in order_attachments %}
+<div class="mb-3">
+  <p class="small fw-semibold mb-1">
+    <a href="{{ url_for('orders.detail', id=group.order.id) }}">
+      {{ group.order.order_number }}
+    </a>
+    <span class="text-muted ms-1">{{ group.order.date_received.strftime('%Y-%m-%d') }}</span>
+  </p>
+  <div class="row g-2">
+    {% for att in group.attachments %}
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+      <div class="card h-100">
+        <a href="{{ url_for('attachments.serve_file', id=att.id) }}" target="_blank"
+           class="text-decoration-none">
+          {% if att.is_image %}
+          <img src="{{ url_for('attachments.thumbnail', id=att.id) }}"
+               class="card-img-top"
+               alt="{{ att.filename }}"
+               style="height: 120px; object-fit: cover;"
+               loading="lazy">
+          {% else %}
+          <div class="card-img-top d-flex align-items-center justify-content-center bg-light"
+               style="height: 120px;">
+            <i class="bi bi-file-earmark-pdf text-danger" style="font-size: 2.5rem;"></i>
+          </div>
+          {% endif %}
+        </a>
+        <div class="card-body p-2">
+          <p class="card-text small text-truncate mb-0" title="{{ att.filename }}">
+            {{ att.filename }}
+          </p>
+          {% if att.description %}
+          <p class="card-text small text-muted text-truncate mb-0" title="{{ att.description }}">
+            {{ att.description }}
+          </p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endfor %}
+{% else %}
+<p class="text-muted small mb-0">No service visit photos.</p>
+{% endif %}

--- a/tests/blueprint/test_attachment_routes.py
+++ b/tests/blueprint/test_attachment_routes.py
@@ -1,0 +1,79 @@
+"""Blueprint tests for attachment routes including unified gallery."""
+
+import pytest
+
+from tests.factories import (
+    AttachmentFactory,
+    CustomerFactory,
+    ServiceItemFactory,
+    ServiceOrderFactory,
+    ServiceOrderItemFactory,
+)
+
+pytestmark = pytest.mark.blueprint
+
+
+def _set_session(db_session):
+    """Configure all factories to use the test DB session."""
+    for factory_cls in (
+        AttachmentFactory,
+        CustomerFactory,
+        ServiceItemFactory,
+        ServiceOrderFactory,
+        ServiceOrderItemFactory,
+    ):
+        factory_cls._meta.sqlalchemy_session = db_session
+
+
+class TestUnifiedGalleryEndpoint:
+    """Tests for GET /attachments/gallery/unified/<service_item_id>."""
+
+    def test_returns_html(self, app, db_session, logged_in_client):
+        """Authenticated request returns 200 with HTML content."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        AttachmentFactory(attachable_type="service_item", attachable_id=item.id)
+
+        resp = logged_in_client.get(
+            f"/attachments/gallery/unified/{item.id}"
+        )
+
+        assert resp.status_code == 200
+        assert b"Item Photos" in resp.data
+
+    def test_requires_login(self, app, client):
+        """Unauthenticated request redirects to login."""
+        resp = client.get("/attachments/gallery/unified/1")
+
+        assert resp.status_code == 302
+        assert "/login" in resp.location
+
+    def test_shows_service_visit_section(self, app, db_session, logged_in_client):
+        """Response includes service visit photos section."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        oi = ServiceOrderItemFactory(service_item=item)
+        AttachmentFactory(
+            attachable_type="service_order_item", attachable_id=oi.id
+        )
+
+        resp = logged_in_client.get(
+            f"/attachments/gallery/unified/{item.id}"
+        )
+
+        assert resp.status_code == 200
+        assert b"Service Visit Photos" in resp.data
+        assert oi.order.order_number.encode() in resp.data
+
+    def test_empty_item(self, app, db_session, logged_in_client):
+        """Item with no attachments shows empty state messages."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+
+        resp = logged_in_client.get(
+            f"/attachments/gallery/unified/{item.id}"
+        )
+
+        assert resp.status_code == 200
+        assert b"No item photos" in resp.data
+        assert b"No service visit photos" in resp.data

--- a/tests/unit/services/test_attachment_service.py
+++ b/tests/unit/services/test_attachment_service.py
@@ -1,0 +1,110 @@
+"""Unit tests for attachment service unified gallery function."""
+
+import pytest
+
+from app.services import attachment_service
+from tests.factories import (
+    AttachmentFactory,
+    CustomerFactory,
+    ServiceItemFactory,
+    ServiceOrderFactory,
+    ServiceOrderItemFactory,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _set_session(db_session):
+    """Configure all factories to use the test DB session."""
+    for factory_cls in (
+        AttachmentFactory,
+        CustomerFactory,
+        ServiceItemFactory,
+        ServiceOrderFactory,
+        ServiceOrderItemFactory,
+    ):
+        factory_cls._meta.sqlalchemy_session = db_session
+
+
+class TestGetUnifiedAttachments:
+    """Tests for get_unified_attachments()."""
+
+    def test_direct_only(self, app, db_session):
+        """Item with direct photos but no service order history."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        AttachmentFactory(attachable_type="service_item", attachable_id=item.id)
+        AttachmentFactory(attachable_type="service_item", attachable_id=item.id)
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(direct) == 2
+        assert len(order_atts) == 0
+
+    def test_from_orders_only(self, app, db_session):
+        """Item with order photos but no direct photos."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        oi = ServiceOrderItemFactory(service_item=item)
+        AttachmentFactory(attachable_type="service_order_item", attachable_id=oi.id)
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(direct) == 0
+        assert len(order_atts) == 1
+        assert len(order_atts[0]["attachments"]) == 1
+        assert order_atts[0]["order_item"] == oi
+
+    def test_combined(self, app, db_session):
+        """Item with both direct and order photos."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        AttachmentFactory(attachable_type="service_item", attachable_id=item.id)
+
+        oi1 = ServiceOrderItemFactory(service_item=item)
+        oi2 = ServiceOrderItemFactory(service_item=item)
+        AttachmentFactory(attachable_type="service_order_item", attachable_id=oi1.id)
+        AttachmentFactory(attachable_type="service_order_item", attachable_id=oi2.id)
+        AttachmentFactory(attachable_type="service_order_item", attachable_id=oi2.id)
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(direct) == 1
+        assert len(order_atts) == 2
+        # Find the group for oi2 — it should have 2 attachments
+        oi2_group = [g for g in order_atts if g["order_item"].id == oi2.id][0]
+        assert len(oi2_group["attachments"]) == 2
+
+    def test_excludes_other_items(self, app, db_session):
+        """Attachments from unrelated items are not included."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        other_item = ServiceItemFactory()
+        AttachmentFactory(attachable_type="service_item", attachable_id=item.id)
+        AttachmentFactory(attachable_type="service_item", attachable_id=other_item.id)
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(direct) == 1
+        assert len(order_atts) == 0
+
+    def test_empty_results(self, app, db_session):
+        """Item with no attachments at all."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(direct) == 0
+        assert len(order_atts) == 0
+
+    def test_order_items_without_attachments_excluded(self, app, db_session):
+        """Order items with no attachments don't appear in results."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        # Create an order item but no attachments for it
+        ServiceOrderItemFactory(service_item=item)
+
+        direct, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert len(order_atts) == 0


### PR DESCRIPTION
## Summary
- Add `get_unified_attachments()` to the attachment service layer, querying both direct item attachments and attachments from all service order items referencing the equipment
- Add `GET /attachments/gallery/unified/<service_item_id>` endpoint returning an HTMX-loadable HTML fragment
- Update item detail template with a "Complete Photo History" card that loads the unified gallery on page load
- Create `unified_gallery.html` partial with "Item Photos" and "Service Visit Photos" sections, grouped by service order with links

## Test plan
- [x] 6 unit tests for `get_unified_attachments()` (direct only, orders only, combined, excludes other items, empty, order items without attachments)
- [x] 4 blueprint tests (returns HTML, requires login, shows service visit section, empty state)
- [x] All 10 new tests passing

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)