### PR TITLE
Update planning docs for remote issue intake and PR policy

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -485,6 +485,9 @@
   - 4B order/dashboard integration discovery
   - 4C invoice/payment integration discovery
   - 4D equipment/invite/email integration discovery
+- Pulled remote GitHub backlog into planning: open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) extends the Wave 3 shipping foundation into real-time carrier integrations and is tracked as a follow-on after Wave 4 unless portal/invoice work forces earlier extraction
+- Process correction: every new feature, fix, or docs lane now requires an isolated worktree, a remote feature branch, and a GitHub PR before merge to `master`
+- Historical exception: the Wave 3 recovery and Wave 4 kickoff commits on `master` (`3bfd7ae` through `a6db2de`) were pushed without PRs and cannot be turned into true reviewable PRs retroactively without rewriting published history
 
 **Wave 5: Final Polish** (3 agents)
 - [ ] 5A: Capture missing screenshots

--- a/README.plan
+++ b/README.plan
@@ -161,6 +161,9 @@ As of 2026-03-24:
 - Waves 1-3 of Sprint `2026-03-22B` are complete and pushed on `master`
 - The next execution stage is **Wave 4: Customer Portal**
 - Final follow-up stage after Wave 4 is **Wave 5: Final Polish**
+- Every new feature, fix, or docs lane now requires an isolated worktree, a remote feature branch, and a GitHub PR before merge to `master`
+- Remote issue intake is now part of active planning; open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) is a follow-on expansion of the shipping framework for real-time carriers
+- Recent Wave 3 recovery / Wave 4 kickoff direct pushes on `master` are a historical exception and are not cleanly backfillable into real review PRs without rewriting published history
 
 ### Wave 4: Customer Portal (parallel)
 

--- a/docs/review/consolidated_todos.md
+++ b/docs/review/consolidated_todos.md
@@ -3,6 +3,8 @@
 Prioritized findings from 4 parallel audits: code, documentation, test suite, and security.
 Use this as input for planning the next sprint.
 
+Remote backlog intake note: GitHub open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) adds a follow-on shipping-provider expansion (real-time carrier integrations) that is not part of the original four audits. It should be planned separately from the remaining audit items below.
+
 ---
 
 ## P1 — High Priority (Fix Before Next Release)
@@ -104,6 +106,7 @@ Status note: items 1, 4, 5, 6, 7, 8, 9, and 10 below have already been implement
 8. **Auto-populate last_service_date** — Set when order transitions to "completed".
 9. **Audit log export** — CSV/XLSX export for compliance.
 10. **Password recovery via email** — Enable Flask-Security's recovery flow (email now works).
+11. **Real-time carrier shipping framework** — Tracked separately as GitHub issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46); extends the current flat-rate/pluggable shipping base with carrier APIs.
 
 ---
 


### PR DESCRIPTION
## Summary\n- pull open remote issue #46 into the planning docs as a follow-on backlog item\n- make the remote branch + GitHub PR requirement explicit for every new lane\n- record the recent direct-to-master Wave 3/Wave 4 kickoff commits as a historical exception rather than pretending they can be cleanly backfilled\n\n## Testing\n- not run (docs-only changes)