### PR TITLE
Add customer portal auth foundation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -152,6 +152,7 @@ def _register_blueprints(app):
     from app.blueprints.notifications import notifications_bp
     from app.blueprints.orders import orders_bp
     from app.blueprints.price_list import price_list_bp
+    from app.blueprints.portal import portal_bp
     from app.blueprints.reports import reports_bp
     from app.blueprints.search import search_bp
     from app.blueprints.tools import tools_bp
@@ -170,6 +171,7 @@ def _register_blueprints(app):
     app.register_blueprint(notifications_bp)
     app.register_blueprint(orders_bp)
     app.register_blueprint(price_list_bp)
+    app.register_blueprint(portal_bp)
     app.register_blueprint(reports_bp)
     app.register_blueprint(search_bp)
     app.register_blueprint(tools_bp)
@@ -261,6 +263,12 @@ def _apply_rate_limits(app):
             "10/minute"
         )(login_view)
 
+    portal_login_view = app.view_functions.get("portal.login")
+    if portal_login_view is not None:
+        app.view_functions["portal.login"] = limiter.limit(
+            "10/minute"
+        )(portal_login_view)
+
     # Rate-limit password reset endpoint (prevents email enumeration)
     reset_view = app.view_functions.get("security.reset_password")
     if reset_view is not None:
@@ -272,6 +280,12 @@ def _apply_rate_limits(app):
         app.view_functions["security.forgot_password"] = limiter.limit(
             "5/minute"
         )(forgot_view)
+
+    portal_activate_view = app.view_functions.get("portal.activate")
+    if portal_activate_view is not None:
+        app.view_functions["portal.activate"] = limiter.limit(
+            "5/minute"
+        )(portal_activate_view)
 
     # Rate-limit API-like search/export endpoints
     for endpoint_name in ("search.search", "search.autocomplete",

--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -18,6 +18,7 @@ from app.blueprints.items import items_bp
 from app.blueprints.notifications import notifications_bp
 from app.blueprints.orders import orders_bp
 from app.blueprints.price_list import price_list_bp
+from app.blueprints.portal import portal_bp
 from app.blueprints.reports import reports_bp
 from app.blueprints.search import search_bp
 from app.blueprints.tools import tools_bp
@@ -37,6 +38,7 @@ __all__ = [
     "notifications_bp",
     "orders_bp",
     "price_list_bp",
+    "portal_bp",
     "reports_bp",
     "search_bp",
     "tools_bp",

--- a/app/blueprints/portal/__init__.py
+++ b/app/blueprints/portal/__init__.py
@@ -1,0 +1,197 @@
+"""Customer portal blueprint.
+
+This namespace keeps customer-facing auth isolated from the internal
+Flask-Security user system. Portal users are tracked in separate tables
+and stored in a separate session key.
+"""
+
+from datetime import datetime
+from functools import wraps
+from urllib.parse import urljoin, urlparse
+
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from werkzeug.local import LocalProxy
+
+from app.extensions import db
+from app.forms.portal import PortalActivationForm, PortalLoginForm
+from app.models.portal_user import (
+    PORTAL_TOKEN_PURPOSE_ACTIVATION,
+    PortalAccessToken,
+    PortalUser,
+)
+
+portal_bp = Blueprint("portal", __name__, url_prefix="/portal")
+
+
+class PortalAnonymousUser:
+    """Fallback object for unauthenticated portal sessions."""
+
+    is_authenticated = False
+    is_anonymous = True
+    is_active = False
+    email = None
+    customer = None
+    display_name = "Guest"
+
+    def get_id(self):
+        return None
+
+
+def _utcnow():
+    return datetime.utcnow()
+
+
+def _get_portal_user():
+    user_id = session.get("portal_user_id")
+    if user_id is None:
+        return PortalAnonymousUser()
+
+    user = db.session.get(PortalUser, user_id)
+    if user is None or not user.active:
+        session.pop("portal_user_id", None)
+        session.pop("portal_remember", None)
+        return PortalAnonymousUser()
+
+    return user
+
+
+portal_current_user = LocalProxy(_get_portal_user)
+
+
+def _safe_next_url(target):
+    if not target:
+        return None
+    base = request.host_url
+    test_url = urlparse(urljoin(base, target))
+    if test_url.scheme not in {"http", "https"}:
+        return None
+    if test_url.netloc != urlparse(base).netloc:
+        return None
+    return target
+
+
+def portal_login_required(view):
+    """Decorator for portal-only routes."""
+
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not portal_current_user.is_authenticated:
+            flash("Please sign in to continue.", "warning")
+            next_url = request.full_path if request.query_string else request.path
+            return redirect(url_for("portal.login", next=next_url))
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _login_portal_user(user, remember=False):
+    session["portal_user_id"] = user.id
+    session["portal_remember"] = bool(remember)
+    session.permanent = bool(remember)
+
+    user.last_login_at = user.current_login_at
+    user.current_login_at = _utcnow()
+    user.login_count = (user.login_count or 0) + 1
+
+
+@portal_bp.app_context_processor
+def inject_portal_user():
+    return {"portal_current_user": portal_current_user}
+
+
+@portal_bp.route("/")
+def index():
+    if portal_current_user.is_authenticated:
+        return redirect(url_for("portal.dashboard"))
+    return redirect(url_for("portal.login"))
+
+
+@portal_bp.route("/login", methods=["GET", "POST"])
+def login():
+    if portal_current_user.is_authenticated:
+        return redirect(url_for("portal.dashboard"))
+
+    form = PortalLoginForm()
+    next_url = _safe_next_url(request.args.get("next") or request.form.get("next"))
+
+    if form.validate_on_submit():
+        email = form.email.data.strip().lower()
+        user = PortalUser.query.filter_by(email=email).first()
+        if user and user.active and user.check_password(form.password.data):
+            _login_portal_user(user, remember=form.remember.data)
+            db.session.commit()
+            flash("Signed in to the customer portal.", "success")
+            return redirect(next_url or url_for("portal.dashboard"))
+        flash("Invalid email or password.", "danger")
+
+    return render_template("portal/login.html", form=form, next_url=next_url)
+
+
+@portal_bp.route("/logout", methods=["POST"])
+def logout():
+    session.pop("portal_user_id", None)
+    session.pop("portal_remember", None)
+    session.permanent = False
+    flash("You have been signed out of the customer portal.", "info")
+    return redirect(url_for("portal.login"))
+
+
+@portal_bp.route("/dashboard")
+@portal_login_required
+def dashboard():
+    return render_template("portal/dashboard.html")
+
+
+@portal_bp.route("/activate/<token>", methods=["GET", "POST"])
+def activate(token):
+    token_record = PortalAccessToken.lookup_valid_token(token)
+    if token_record is None or token_record.purpose != PORTAL_TOKEN_PURPOSE_ACTIVATION:
+        abort(404)
+
+    form = PortalActivationForm()
+
+    if form.validate_on_submit():
+        user = token_record.portal_user
+        if user is None:
+            user = PortalUser.query.filter_by(
+                customer_id=token_record.customer_id,
+                email=token_record.email,
+            ).one_or_none()
+        if user is None:
+            user = PortalUser(
+                customer_id=token_record.customer_id,
+                email=token_record.email,
+                active=False,
+            )
+            db.session.add(user)
+
+        user.email = token_record.email
+        user.customer_id = token_record.customer_id
+        user.set_password(form.password.data)
+        user.active = True
+        user.confirmed_at = _utcnow()
+
+        token_record.consume(user)
+        db.session.commit()
+
+        _login_portal_user(user, remember=False)
+        db.session.commit()
+
+        flash("Your portal account is ready.", "success")
+        return redirect(url_for("portal.dashboard"))
+
+    return render_template(
+        "portal/activate.html",
+        form=form,
+        token_record=token_record,
+        token=token,
+    )

--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -12,6 +12,7 @@ Convenience imports are provided so that views can do::
 from app.forms.applied_service import AppliedServiceForm
 from app.forms.auth import ExtendedLoginForm
 from app.forms.customer import CustomerForm, CustomerSearchForm
+from app.forms.portal import PortalActivationForm, PortalLoginForm
 from app.forms.inventory import InventoryItemForm, InventorySearchForm, StockAdjustmentForm
 from app.forms.item import DrysuitDetailsForm, ServiceItemForm
 from app.forms.labor import LaborEntryForm
@@ -25,6 +26,8 @@ from app.forms.service_order_item import ServiceOrderItemForm
 __all__ = [
     "AppliedServiceForm",
     "ExtendedLoginForm",
+    "PortalActivationForm",
+    "PortalLoginForm",
     "CustomerForm",
     "CustomerSearchForm",
     "DrysuitDetailsForm",

--- a/app/forms/portal.py
+++ b/app/forms/portal.py
@@ -1,0 +1,37 @@
+"""Portal authentication forms."""
+
+from flask_wtf import FlaskForm
+from wtforms import BooleanField, PasswordField, StringField, SubmitField
+from wtforms.validators import DataRequired, Email, EqualTo, Length
+
+
+class PortalLoginForm(FlaskForm):
+    """Separate login form for customer portal users."""
+
+    email = StringField(
+        "Email Address",
+        validators=[DataRequired(), Email(), Length(max=255)],
+    )
+    password = PasswordField(
+        "Password",
+        validators=[DataRequired(), Length(max=255)],
+    )
+    remember = BooleanField("Remember me", default=False)
+    submit = SubmitField("Sign In")
+
+
+class PortalActivationForm(FlaskForm):
+    """Initial password setup for an invited portal user."""
+
+    password = PasswordField(
+        "Password",
+        validators=[DataRequired(), Length(min=8, max=255)],
+    )
+    confirm_password = PasswordField(
+        "Confirm Password",
+        validators=[
+            DataRequired(),
+            EqualTo("password", message="Passwords must match."),
+        ],
+    )
+    submit = SubmitField("Activate Account")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,14 @@ discover every model by importing this single package.
 """
 
 from app.models.user import Role, User, user_roles
+from app.models.portal_user import (
+    PORTAL_TOKEN_PURPOSE_ACTIVATION,
+    PORTAL_TOKEN_PURPOSE_INVITE,
+    PORTAL_TOKEN_PURPOSE_PASSWORD_RESET,
+    PORTAL_TOKEN_PURPOSES,
+    PortalAccessToken,
+    PortalUser,
+)
 from app.models.customer import Customer
 from app.models.service_item import ServiceItem
 from app.models.drysuit_details import DrysuitDetails
@@ -34,6 +42,12 @@ __all__ = [
     "Role",
     "User",
     "user_roles",
+    "PortalUser",
+    "PortalAccessToken",
+    "PORTAL_TOKEN_PURPOSE_ACTIVATION",
+    "PORTAL_TOKEN_PURPOSE_INVITE",
+    "PORTAL_TOKEN_PURPOSE_PASSWORD_RESET",
+    "PORTAL_TOKEN_PURPOSES",
     "Customer",
     "ServiceItem",
     "DrysuitDetails",

--- a/app/models/customer.py
+++ b/app/models/customer.py
@@ -70,6 +70,11 @@ class Customer(TimestampMixin, SoftDeleteMixin, AuditMixin, db.Model):
         back_populates="customer",
         lazy="dynamic",
     )
+    portal_users = db.relationship(
+        "PortalUser",
+        back_populates="customer",
+        lazy="dynamic",
+    )
 
     # --- Table indexes ---
     __table_args__ = (

--- a/app/models/portal_user.py
+++ b/app/models/portal_user.py
@@ -1,0 +1,220 @@
+"""Portal customer-auth models.
+
+Portal accounts are distinct from internal Flask-Security users. They are
+linked to customers and use a separate password hash plus a separate token
+table for invite/activation flows.
+"""
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import validates
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from app.extensions import db
+from app.models.mixins import TimestampMixin
+
+
+PORTAL_TOKEN_PURPOSE_ACTIVATION = "activation"
+PORTAL_TOKEN_PURPOSE_INVITE = "invite"
+PORTAL_TOKEN_PURPOSE_PASSWORD_RESET = "password_reset"
+PORTAL_TOKEN_PURPOSES = (
+    PORTAL_TOKEN_PURPOSE_ACTIVATION,
+    PORTAL_TOKEN_PURPOSE_INVITE,
+    PORTAL_TOKEN_PURPOSE_PASSWORD_RESET,
+)
+
+
+def _normalize_email(value):
+    if value is None:
+        return None
+    return value.strip().lower()
+
+
+def _hash_token(raw_token):
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+def _utcnow():
+    return datetime.utcnow()
+
+
+class PortalUser(TimestampMixin, db.Model):
+    """Customer portal account.
+
+    A portal user belongs to exactly one customer and can be activated via a
+    separate invite token. Internal staff accounts remain in ``users``.
+    """
+
+    __tablename__ = "portal_users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    customer_id = db.Column(
+        db.Integer,
+        db.ForeignKey("customers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    active = db.Column(db.Boolean, nullable=False, default=False)
+    confirmed_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    last_login_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    current_login_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    login_count = db.Column(db.Integer, nullable=False, default=0)
+
+    customer = db.relationship("Customer", back_populates="portal_users")
+    access_tokens = db.relationship(
+        "PortalAccessToken",
+        back_populates="portal_user",
+        lazy="dynamic",
+    )
+
+    @validates("email")
+    def validate_email(self, key, value):
+        value = _normalize_email(value)
+        if not value:
+            raise ValueError("email is required for portal users")
+        return value
+
+    def set_password(self, raw_password):
+        self.password_hash = generate_password_hash(raw_password)
+
+    def check_password(self, raw_password):
+        return check_password_hash(self.password_hash, raw_password)
+
+    @property
+    def display_name(self):
+        if self.customer and self.customer.display_name:
+            return self.customer.display_name
+        return self.email
+
+    @property
+    def is_authenticated(self):
+        return True
+
+    @property
+    def is_anonymous(self):
+        return False
+
+    @property
+    def is_active(self):
+        return bool(self.active)
+
+    def get_id(self):
+        return str(self.id)
+
+    def __repr__(self):
+        return f"<PortalUser {self.email!r}>"
+
+
+class PortalAccessToken(TimestampMixin, db.Model):
+    """Hashed invite/activation token for portal accounts."""
+
+    __tablename__ = "portal_access_tokens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    customer_id = db.Column(
+        db.Integer,
+        db.ForeignKey("customers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    portal_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("portal_users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    email = db.Column(db.String(255), nullable=False, index=True)
+    purpose = db.Column(
+        db.String(32),
+        nullable=False,
+        default=PORTAL_TOKEN_PURPOSE_ACTIVATION,
+        index=True,
+    )
+    token_hash = db.Column(db.String(64), unique=True, nullable=False, index=True)
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
+    used_at = db.Column(db.DateTime(timezone=True), nullable=True)
+
+    customer = db.relationship("Customer")
+    portal_user = db.relationship("PortalUser", back_populates="access_tokens")
+
+    @validates("email")
+    def validate_email(self, key, value):
+        value = _normalize_email(value)
+        if not value:
+            raise ValueError("email is required for portal tokens")
+        return value
+
+    @validates("purpose")
+    def validate_purpose(self, key, value):
+        if value not in PORTAL_TOKEN_PURPOSES:
+            raise ValueError(
+                f"purpose must be one of {PORTAL_TOKEN_PURPOSES}, got {value!r}"
+            )
+        return value
+
+    @property
+    def is_expired(self):
+        return self.expires_at <= _utcnow()
+
+    @property
+    def is_used(self):
+        return self.used_at is not None
+
+    @property
+    def is_valid(self):
+        return not self.is_used and not self.is_expired
+
+    @classmethod
+    def issue_activation(cls, customer, email, expires_in=timedelta(hours=72)):
+        """Create a fresh activation token and return the row plus raw token."""
+        customer_id = getattr(customer, "id", customer)
+        if customer_id is None:
+            raise ValueError("customer is required for portal activation tokens")
+        normalized_email = _normalize_email(email)
+        if not normalized_email:
+            raise ValueError("email is required for portal activation tokens")
+
+        existing_user = PortalUser.query.filter_by(
+            customer_id=customer_id,
+            email=normalized_email,
+        ).one_or_none()
+
+        # Revoke any previously-issued unused activation links for the same
+        # customer/email pair before creating the new one.
+        db.session.query(cls).filter(
+            cls.customer_id == customer_id,
+            cls.email == normalized_email,
+            cls.purpose == PORTAL_TOKEN_PURPOSE_ACTIVATION,
+            cls.used_at.is_(None),
+        ).update({cls.used_at: _utcnow()}, synchronize_session=False)
+
+        raw_token = secrets.token_urlsafe(32)
+        token = cls(
+            customer_id=customer_id,
+            email=normalized_email,
+            purpose=PORTAL_TOKEN_PURPOSE_ACTIVATION,
+            token_hash=_hash_token(raw_token),
+            expires_at=_utcnow() + expires_in,
+            portal_user=existing_user,
+        )
+        db.session.add(token)
+        return token, raw_token
+
+    @classmethod
+    def lookup_valid_token(cls, raw_token):
+        token_hash = _hash_token(raw_token)
+        token = cls.query.filter_by(token_hash=token_hash).first()
+        if token is None or not token.is_valid:
+            return None
+        return token
+
+    def consume(self, portal_user):
+        self.portal_user = portal_user
+        self.used_at = _utcnow()
+
+    def __repr__(self):
+        return f"<PortalAccessToken {self.purpose!r} {self.email!r}>"

--- a/app/templates/portal/activate.html
+++ b/app/templates/portal/activate.html
@@ -1,0 +1,31 @@
+{% extends "portal/base.html" %}
+{% from "macros/forms.html" import render_field %}
+
+{% block title %}Activate Portal Account - {{ company_name }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center" style="min-height: 66vh;">
+  <div class="col-12 col-md-10 col-lg-7 col-xl-6">
+    <div class="portal-card rounded-4 p-4 p-lg-5">
+      <div class="mb-4">
+        <div class="portal-caption text-muted mb-2">Activation</div>
+        <h1 class="h3 mb-2">Set your portal password</h1>
+        <p class="text-muted mb-0">
+          This link is tied to {{ token_record.email }} and the customer account it was issued for.
+        </p>
+      </div>
+
+      <form method="POST" action="{{ url_for('portal.activate', token=token) }}" novalidate>
+        {{ form.hidden_tag() }}
+        {{ render_field(form.password, placeholder="Create a password") }}
+        {{ render_field(form.confirm_password, placeholder="Re-enter the password") }}
+        <div class="d-grid">
+          <button type="submit" class="btn btn-primary btn-lg">
+            <i class="bi bi-shield-check me-1"></i> Activate account
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/portal/base.html
+++ b/app/templates/portal/base.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
+  <title>{% block title %}Customer Portal - Dive Service Management{% endblock %}</title>
+  <link href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='vendor/bootstrap-icons.min.css') }}" rel="stylesheet">
+  <style>
+    :root {
+      --portal-ink: #10233d;
+      --portal-accent: #2f7cff;
+      --portal-accent-2: #14b8a6;
+      --portal-surface: rgba(255, 255, 255, 0.92);
+    }
+
+    body.portal-shell {
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at top left, rgba(47, 124, 255, 0.22), transparent 34%),
+        radial-gradient(circle at bottom right, rgba(20, 184, 166, 0.18), transparent 30%),
+        linear-gradient(135deg, #081120 0%, #10233d 48%, #173660 100%);
+      color: #f8fbff;
+    }
+
+    .portal-shell__wrap {
+      position: relative;
+      min-height: 100vh;
+      overflow: hidden;
+    }
+
+    .portal-shell__glow {
+      position: absolute;
+      inset: auto auto 10% 5%;
+      width: 18rem;
+      height: 18rem;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(47, 124, 255, 0.28), transparent 70%);
+      filter: blur(12px);
+      pointer-events: none;
+    }
+
+    .portal-card {
+      background: var(--portal-surface);
+      color: var(--portal-ink);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      backdrop-filter: blur(18px);
+      box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.25);
+    }
+
+    .portal-brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .portal-brand__mark {
+      width: 2.75rem;
+      height: 2.75rem;
+      border-radius: 0.9rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, var(--portal-accent), var(--portal-accent-2));
+      color: white;
+      box-shadow: 0 0.85rem 1.8rem rgba(47, 124, 255, 0.35);
+    }
+
+    .portal-caption {
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      font-size: 0.74rem;
+      color: rgba(248, 251, 255, 0.72);
+    }
+  </style>
+  {% block head %}{% endblock %}
+</head>
+<body class="portal-shell">
+  <div class="portal-shell__wrap">
+    <div class="portal-shell__glow"></div>
+
+    <div class="container py-4 py-lg-5 position-relative">
+      <div class="d-flex align-items-center justify-content-between mb-4">
+        <a class="portal-brand" href="{{ url_for('portal.index') }}">
+          <span class="portal-brand__mark">
+            <i class="bi bi-water"></i>
+          </span>
+          <span>
+            <span class="portal-caption d-block">Customer Portal</span>
+            <strong class="fs-5">{{ company_name }}</strong>
+          </span>
+        </a>
+
+        {% if portal_current_user.is_authenticated %}
+        <form method="POST" action="{{ url_for('portal.logout') }}" class="d-inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-outline-light btn-sm">
+            <i class="bi bi-box-arrow-right me-1"></i> Sign out
+          </button>
+        </form>
+        {% endif %}
+      </div>
+
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="mb-4">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show"
+                 role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </div>
+  </div>
+
+  <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}"></script>
+</body>
+</html>

--- a/app/templates/portal/dashboard.html
+++ b/app/templates/portal/dashboard.html
@@ -1,0 +1,34 @@
+{% extends "portal/base.html" %}
+
+{% block title %}Portal Dashboard - {{ company_name }}{% endblock %}
+
+{% block content %}
+<div class="row g-4">
+  <div class="col-lg-7">
+    <div class="portal-card rounded-4 p-4 p-lg-5">
+      <div class="portal-caption text-muted mb-2">Portal dashboard</div>
+      <h1 class="h2 mb-3">Welcome, {{ portal_current_user.display_name }}</h1>
+      <p class="text-muted mb-0">
+        This is the portal foundation. Customer-specific orders, invoices, and equipment
+        views will land here in the next wave.
+      </p>
+    </div>
+  </div>
+
+  <div class="col-lg-5">
+    <div class="portal-card rounded-4 p-4 p-lg-5 h-100">
+      <h2 class="h5 mb-3">Account</h2>
+      <dl class="row mb-0">
+        <dt class="col-5 text-muted">Email</dt>
+        <dd class="col-7">{{ portal_current_user.email }}</dd>
+        <dt class="col-5 text-muted">Customer</dt>
+        <dd class="col-7">{{ portal_current_user.customer.display_name }}</dd>
+        <dt class="col-5 text-muted">Status</dt>
+        <dd class="col-7">
+          <span class="badge text-bg-success">Active</span>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/portal/login.html
+++ b/app/templates/portal/login.html
@@ -1,0 +1,43 @@
+{% extends "portal/base.html" %}
+{% from "macros/forms.html" import render_field, render_checkbox %}
+
+{% block title %}Portal Login - {{ company_name }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center align-items-center" style="min-height: 68vh;">
+  <div class="col-12 col-md-10 col-lg-8 col-xxl-7">
+    <div class="row g-0 portal-card rounded-4 overflow-hidden">
+      <div class="col-lg-5 p-4 p-lg-5 text-white" style="background: linear-gradient(160deg, #10233d 0%, #173660 52%, #2f7cff 100%);">
+        <div class="h-100 d-flex flex-column justify-content-between">
+          <div>
+            <div class="portal-caption mb-3">Customer access</div>
+            <h1 class="display-6 fw-semibold">Service history, invoices, and updates in one place.</h1>
+          </div>
+          <p class="mb-0 mt-4 text-white-50">
+            Sign in with the email address tied to your service account. If you have
+            not activated your account yet, use the invitation link from your shop.
+          </p>
+        </div>
+      </div>
+
+      <div class="col-lg-7 p-4 p-lg-5">
+        <h2 class="h4 mb-1">Sign in</h2>
+        <p class="text-muted mb-4">Use your portal credentials to continue.</p>
+
+        <form method="POST" action="{{ url_for('portal.login') }}" novalidate>
+          {{ form.hidden_tag() }}
+          <input type="hidden" name="next" value="{{ next_url or '' }}">
+          {{ render_field(form.email, placeholder="name@example.com") }}
+          {{ render_field(form.password, placeholder="Enter your password") }}
+          {{ render_checkbox(form.remember) }}
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary btn-lg">
+              <i class="bi bi-box-arrow-in-right me-1"></i> Sign in
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/migrations/versions/q4a5b6c7d8e9_portal_auth_foundation.py
+++ b/migrations/versions/q4a5b6c7d8e9_portal_auth_foundation.py
@@ -1,0 +1,106 @@
+"""Portal auth foundation tables.
+
+Revision ID: q4a5b6c7d8e9
+Revises: j0e1f2g3h4i5, l2g3h4i5j6k7
+Create Date: 2026-03-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "q4a5b6c7d8e9"
+down_revision = ("j0e1f2g3h4i5", "l2g3h4i5j6k7")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "portal_users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("customer_id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column(
+            "active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("current_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "login_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index("ix_portal_users_customer_id", "portal_users", ["customer_id"])
+    op.create_index("ix_portal_users_email", "portal_users", ["email"])
+
+    op.create_table(
+        "portal_access_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("customer_id", sa.Integer(), nullable=False),
+        sa.Column("portal_user_id", sa.Integer(), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column(
+            "purpose",
+            sa.String(length=32),
+            nullable=False,
+            server_default="activation",
+        ),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["customer_id"], ["customers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["portal_user_id"], ["portal_users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        "ix_portal_access_tokens_customer_id",
+        "portal_access_tokens",
+        ["customer_id"],
+    )
+    op.create_index(
+        "ix_portal_access_tokens_email",
+        "portal_access_tokens",
+        ["email"],
+    )
+    op.create_index(
+        "ix_portal_access_tokens_expires_at",
+        "portal_access_tokens",
+        ["expires_at"],
+    )
+    op.create_index(
+        "ix_portal_access_tokens_portal_user_id",
+        "portal_access_tokens",
+        ["portal_user_id"],
+    )
+    op.create_index(
+        "ix_portal_access_tokens_purpose",
+        "portal_access_tokens",
+        ["purpose"],
+    )
+    op.create_index(
+        "ix_portal_access_tokens_token_hash",
+        "portal_access_tokens",
+        ["token_hash"],
+    )
+
+
+def downgrade():
+    op.drop_table("portal_access_tokens")
+    op.drop_table("portal_users")

--- a/tests/blueprint/test_portal_auth.py
+++ b/tests/blueprint/test_portal_auth.py
@@ -1,0 +1,198 @@
+"""Blueprint tests for portal authentication routes."""
+
+import pytest
+
+from app.models.portal_user import PortalAccessToken, PortalUser
+from tests.factories import CustomerFactory
+
+
+pytestmark = pytest.mark.blueprint
+
+
+def _set_session(db_session):
+    CustomerFactory._meta.sqlalchemy_session = db_session
+
+
+def _create_portal_user(db_session, customer, email="portal@example.com", password="portal-pass"):
+    user = PortalUser(customer_id=customer.id, email=email)
+    user.set_password(password)
+    user.active = True
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def test_portal_root_redirects_to_login(client):
+    """Anonymous GET /portal/ redirects to the portal login page."""
+    response = client.get("/portal/")
+    assert response.status_code == 302
+    assert "/portal/login" in response.location
+
+
+def test_portal_login_page_renders(client):
+    """GET /portal/login renders the customer portal sign-in page."""
+    response = client.get("/portal/login")
+    assert response.status_code == 200
+    html = response.data.decode().lower()
+    assert "sign in" in html
+    assert "email" in html
+
+
+def test_portal_login_failure_stays_on_page(app, db_session, client):
+    """Wrong portal credentials should not authenticate the session."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Login", last_name="Failure")
+    _create_portal_user(db_session, customer, password="correct-pass")
+
+    response = client.post(
+        "/portal/login",
+        data={"email": "portal@example.com", "password": "wrong-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert response.location is None
+    assert b"Invalid email or password." in response.data
+
+
+def test_portal_activation_flow_creates_user_and_logs_in(app, db_session, client):
+    """Valid activation token creates a portal account and logs the user in."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Activation", last_name="Target")
+    token_row, raw_token = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="activation@example.com",
+    )
+    db_session.commit()
+
+    response = client.get(f"/portal/activate/{raw_token}")
+    assert response.status_code == 200
+    assert b"Set your portal password" in response.data
+
+    response = client.post(
+        f"/portal/activate/{raw_token}",
+        data={"password": "portal-pass", "confirm_password": "portal-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/portal/dashboard" in response.location
+
+    created_user = PortalUser.query.filter_by(email="activation@example.com").one()
+    assert created_user.active is True
+    assert created_user.customer_id == customer.id
+    assert token_row.used_at is not None
+
+    portal_response = client.get("/portal/dashboard")
+    assert portal_response.status_code == 200, portal_response.location
+    assert b"Welcome" in portal_response.data
+
+
+def test_portal_activation_rejects_stale_token_after_reissue(app, db_session, client):
+    """An older token should be rejected after a newer one has been issued and used."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Stale", last_name="Target")
+    old_token, old_raw = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="stale@example.com",
+    )
+    db_session.commit()
+
+    new_token, new_raw = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="stale@example.com",
+    )
+    db_session.commit()
+
+    response = client.post(
+        f"/portal/activate/{new_raw}",
+        data={"password": "portal-pass", "confirm_password": "portal-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/portal/dashboard" in response.location
+
+    db_session.refresh(old_token)
+    db_session.refresh(new_token)
+
+    stale_response = client.get(f"/portal/activate/{old_raw}", follow_redirects=False)
+    assert stale_response.status_code == 404
+
+    created_user = PortalUser.query.filter_by(email="stale@example.com").one()
+    assert created_user.active is True
+    assert new_token.portal_user_id == created_user.id
+    assert old_token.used_at is not None
+
+
+def test_portal_used_token_rejected_after_activation(app, db_session, client):
+    """A token cannot be reused once it has already activated the account."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Used", last_name="Target")
+    token, raw_token = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="used@example.com",
+    )
+    db_session.commit()
+
+    response = client.post(
+        f"/portal/activate/{raw_token}",
+        data={"password": "portal-pass", "confirm_password": "portal-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    db_session.refresh(token)
+
+    reused_get = client.get(f"/portal/activate/{raw_token}", follow_redirects=False)
+    assert reused_get.status_code == 404
+
+    reused_post = client.post(
+        f"/portal/activate/{raw_token}",
+        data={"password": "portal-pass-2", "confirm_password": "portal-pass-2"},
+        follow_redirects=False,
+    )
+    assert reused_post.status_code == 404
+    assert token.used_at is not None
+
+
+def test_portal_login_does_not_authenticate_internal_dashboard(app, db_session, client):
+    """Logging into the portal should not grant Flask-Security staff access."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Separate", last_name="Session")
+    _create_portal_user(db_session, customer)
+
+    response = client.post(
+        "/portal/login",
+        data={"email": "portal@example.com", "password": "portal-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/portal/dashboard" in response.location
+
+    internal_response = client.get("/dashboard/", follow_redirects=False)
+    assert internal_response.status_code == 302
+    assert "/login" in internal_response.location
+
+
+def test_portal_logout_is_post_only(app, db_session, client):
+    """Portal logout should be a POST-only action and sign the user out."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Logout", last_name="Target")
+    _create_portal_user(db_session, customer)
+
+    response = client.post(
+        "/portal/login",
+        data={"email": "portal@example.com", "password": "portal-pass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/portal/dashboard" in response.location
+
+    logout_get = client.get("/portal/logout", follow_redirects=False)
+    assert logout_get.status_code == 405
+
+    logout_post = client.post("/portal/logout", follow_redirects=False)
+    assert logout_post.status_code == 302
+    assert "/portal/login" in logout_post.location
+
+    dashboard_response = client.get("/portal/dashboard", follow_redirects=False)
+    assert dashboard_response.status_code == 302
+    assert "/portal/login" in dashboard_response.location

--- a/tests/unit/models/test_portal_user.py
+++ b/tests/unit/models/test_portal_user.py
@@ -1,0 +1,109 @@
+"""Unit tests for the portal auth models."""
+
+from datetime import timedelta
+
+import pytest
+
+from app.models.portal_user import PortalAccessToken, PortalUser
+from tests.factories import CustomerFactory
+
+
+pytestmark = pytest.mark.unit
+
+
+def _set_session(db_session):
+    CustomerFactory._meta.sqlalchemy_session = db_session
+
+
+def test_portal_user_creation_and_relationship(app, db_session):
+    """Portal users persist separately from internal users and link to customers."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Portal", last_name="Customer")
+
+    user = PortalUser(customer_id=customer.id, email="Portal@Example.com")
+    user.set_password("portal-password")
+    db_session.add(user)
+    db_session.commit()
+
+    fetched = db_session.get(PortalUser, user.id)
+    assert fetched is not None
+    assert fetched.email == "portal@example.com"
+    assert fetched.check_password("portal-password") is True
+    assert fetched.customer.id == customer.id
+    assert fetched.display_name == customer.display_name
+    assert fetched.is_authenticated is True
+    assert fetched.is_anonymous is False
+    assert fetched.is_active is False
+    assert customer.portal_users.count() == 1
+
+
+def test_portal_activation_token_issue_and_lookup(app, db_session):
+    """Activation tokens are hashed at rest and can be looked up by raw token."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Invite", last_name="Target")
+
+    token, raw_token = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="invite@example.com",
+        expires_in=timedelta(hours=1),
+    )
+    db_session.commit()
+
+    assert token.token_hash != raw_token
+    assert len(token.token_hash) == 64
+    assert PortalAccessToken.lookup_valid_token(raw_token) == token
+    assert token.is_valid is True
+
+
+def test_portal_activation_token_reissue_revokes_older_token_and_reuses_user(
+    app, db_session
+):
+    """Reissuing an invite revokes the previous unused token and reuses the account."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Reuse", last_name="Target")
+
+    first_token, first_raw = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="reuse@example.com",
+        expires_in=timedelta(hours=1),
+    )
+    db_session.commit()
+
+    existing_user = PortalUser(customer_id=customer.id, email="reuse@example.com")
+    existing_user.set_password("portal-password")
+    existing_user.active = True
+    db_session.add(existing_user)
+    db_session.commit()
+
+    second_token, second_raw = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="reuse@example.com",
+        expires_in=timedelta(hours=1),
+    )
+    db_session.commit()
+
+    db_session.refresh(first_token)
+    db_session.refresh(second_token)
+
+    assert first_token.used_at is not None
+    assert PortalAccessToken.lookup_valid_token(first_raw) is None
+    assert second_token.portal_user_id == existing_user.id
+    assert PortalAccessToken.lookup_valid_token(second_raw) == second_token
+    assert customer.portal_users.count() == 1
+
+
+def test_portal_activation_token_expiry_and_consumption(app, db_session):
+    """Expired or used tokens are no longer valid."""
+    _set_session(db_session)
+    customer = CustomerFactory(first_name="Expire", last_name="Target")
+    token, raw_token = PortalAccessToken.issue_activation(
+        customer=customer,
+        email="expire@example.com",
+        expires_in=timedelta(minutes=5),
+    )
+    db_session.commit()
+
+    token.used_at = token.expires_at
+    db_session.commit()
+    assert token.is_used is True
+    assert PortalAccessToken.lookup_valid_token(raw_token) is None


### PR DESCRIPTION
## Summary\n- add separate customer portal auth models, forms, blueprint, templates, and migration\n- keep portal sessions isolated from internal Flask-Security users\n- harden activation token handling for reissued invites and stale-link rejection\n\n## Testing\n- docker compose -f docker-compose.test-dev.yml exec -T test pytest tests/unit/models/test_portal_user.py tests/blueprint/test_portal_auth.py tests/blueprint/test_auth_routes.py tests/unit/test_user_model.py -q