### PR TITLE
Harden portal dashboard item scoping

### DIFF
--- a/app/services/portal_service.py
+++ b/app/services/portal_service.py
@@ -87,7 +87,12 @@ def get_order_status_history(customer_id, order_id):
 
 
 def _serialize_order_card(order):
-    item_names = [item.service_item.name for item in order.order_items.all()]
+    visible_items = [
+        item
+        for item in order.order_items.all()
+        if _is_portal_visible_item(item, order.customer_id)
+    ]
+    item_names = [item.service_item.name for item in visible_items]
     summary = order_service.get_order_summary(order.id)
     return {
         "id": order.id,
@@ -97,7 +102,7 @@ def _serialize_order_card(order):
         "date_received": order.date_received,
         "date_promised": order.date_promised,
         "date_completed": order.date_completed,
-        "item_count": len(item_names),
+        "item_count": len(visible_items),
         "item_names": item_names[:3],
         "estimated_total": summary["estimated_total"],
         "is_overdue": order.is_overdue,

--- a/tests/blueprint/test_portal.py
+++ b/tests/blueprint/test_portal.py
@@ -58,6 +58,8 @@ def test_dashboard_shows_only_customer_orders(app, db_session, client):
     customer = CustomerFactory(first_name="Portal", last_name="Owner")
     other_customer = CustomerFactory(first_name="Other", last_name="Owner")
     _create_portal_user(db_session, customer)
+    visible_item = ServiceItemFactory(customer=customer, name="Visible Item")
+    leaked_item = ServiceItemFactory(customer=other_customer, name="Do Not Leak")
 
     own_order = ServiceOrderFactory(
         customer=customer,
@@ -65,6 +67,8 @@ def test_dashboard_shows_only_customer_orders(app, db_session, client):
         date_received=date(2026, 3, 3),
         description="Own order",
     )
+    ServiceOrderItemFactory(order=own_order, service_item=visible_item)
+    ServiceOrderItemFactory(order=own_order, service_item=leaked_item)
     other_order = ServiceOrderFactory(
         customer=other_customer,
         status="intake",
@@ -80,6 +84,8 @@ def test_dashboard_shows_only_customer_orders(app, db_session, client):
     html = response.data.decode()
     assert own_order.order_number in html
     assert other_order.order_number not in html
+    assert "Visible Item" in html
+    assert "Do Not Leak" not in html
 
 
 def test_order_detail_shows_safe_tracking_and_hides_internal_notes(app, db_session, client):

--- a/tests/unit/services/test_portal_service.py
+++ b/tests/unit/services/test_portal_service.py
@@ -40,12 +40,16 @@ def test_get_customer_dashboard_scopes_orders(app, db_session):
     """The portal dashboard should only include the customer's own orders."""
     customer = CustomerFactory(first_name="Portal", last_name="Owner")
     other_customer = CustomerFactory(first_name="Other", last_name="Owner")
+    visible_item = ServiceItemFactory(customer=customer, name="Visible Item")
+    leaked_item = ServiceItemFactory(customer=other_customer, name="Do Not Leak")
 
     active_order = ServiceOrderFactory(
         customer=customer,
         status="ready_for_pickup",
         date_received=date(2026, 3, 1),
     )
+    ServiceOrderItemFactory(order=active_order, service_item=visible_item)
+    ServiceOrderItemFactory(order=active_order, service_item=leaked_item)
     recent_order = ServiceOrderFactory(customer=customer, status="completed", date_received=date(2026, 2, 28))
     ServiceOrderFactory(customer=other_customer, status="intake", date_received=date(2026, 3, 2))
     db_session.commit()
@@ -56,6 +60,8 @@ def test_get_customer_dashboard_scopes_orders(app, db_session):
     assert dashboard["recent_count"] == 2
     assert [order["id"] for order in dashboard["active_orders"]] == [active_order.id]
     assert [order["id"] for order in dashboard["recent_orders"]] == [active_order.id, recent_order.id]
+    assert dashboard["active_orders"][0]["item_names"] == ["Visible Item"]
+    assert dashboard["active_orders"][0]["item_count"] == 1
 
 
 def test_get_customer_order_rejects_other_customer_order(app, db_session):


### PR DESCRIPTION
## Summary\n- filter dashboard order-card item names through the same customer-scoping guard used by portal order detail\n- prevent mislinked order items from leaking another customer's item name on portal dashboard/recent cards\n- add regression coverage at the service and blueprint layers\n\n## Testing\n- docker compose -f docker-compose.test-dev.yml exec -T test pytest tests/unit/services/test_portal_service.py tests/blueprint/test_portal.py tests/blueprint/test_portal_auth.py -q