### PR TITLE
Add portal equipment navigation links

### DIFF
--- a/app/services/portal_service.py
+++ b/app/services/portal_service.py
@@ -134,6 +134,7 @@ def _serialize_order_item(order_item, public_notes, customer_id):
         return None
     return {
         "id": order_item.id,
+        "service_item_id": service_item.id,
         "status": order_item.status,
         "display_status": order_item.status.replace("_", " ").title() if order_item.status else "",
         "work_description": order_item.work_description,

--- a/app/templates/portal/base.html
+++ b/app/templates/portal/base.html
@@ -107,6 +107,7 @@
         <div class="d-flex align-items-center gap-3">
           {% if portal_current_user.is_authenticated %}
           <a class="portal-nav-link small" href="{{ url_for('portal.dashboard') }}">Dashboard</a>
+          <a class="portal-nav-link small" href="{{ url_for('portal.equipment') }}">Equipment</a>
           <a class="portal-nav-link small" href="{{ url_for('portal.invoices') }}">Invoices</a>
           <form method="POST" action="{{ url_for('portal.logout') }}" class="d-inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/app/templates/portal/order_detail.html
+++ b/app/templates/portal/order_detail.html
@@ -64,7 +64,14 @@
           <div class="border rounded-4 p-3 bg-white">
             <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
               <div>
-                <h3 class="h5 mb-1">{{ item.name }}</h3>
+                <h3 class="h5 mb-1">
+                  <a
+                    class="link-primary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover text-decoration-none"
+                    href="{{ url_for('portal.equipment_detail', item_id=item.service_item_id) }}"
+                  >
+                    {{ item.name }}
+                  </a>
+                </h3>
                 <div class="small text-muted">
                   {% if item.brand %}{{ item.brand }}{% endif %}
                   {% if item.brand and item.model %} · {% endif %}

--- a/tests/blueprint/test_portal.py
+++ b/tests/blueprint/test_portal.py
@@ -137,6 +137,7 @@ def test_order_detail_shows_safe_tracking_and_hides_internal_notes(app, db_sessi
     assert "We found a leak near the zipper" in html
     assert "Intake" in html and "Assessment" in html
     assert "Estimated total" in html
+    assert f"/portal/equipment/{item.id}" in html
 
     forbidden = client.get(f"/portal/orders/{other_order.id}")
     assert forbidden.status_code == 404
@@ -154,3 +155,18 @@ def test_dashboard_links_to_order_detail(app, db_session, client):
     response = client.get("/portal/dashboard")
     html = response.data.decode()
     assert f"/portal/orders/{order.id}" in html
+
+
+def test_portal_navigation_links_to_equipment(app, db_session, client):
+    """Authenticated portal pages should expose the equipment surface in nav."""
+    customer = CustomerFactory(first_name="Portal", last_name="Owner")
+    _create_portal_user(db_session, customer)
+    ServiceOrderFactory(customer=customer, status="completed")
+    db_session.commit()
+
+    _login_portal(client)
+
+    response = client.get("/portal/dashboard")
+    assert response.status_code == 200
+    html = response.data.decode()
+    assert "/portal/equipment" in html


### PR DESCRIPTION
## Summary
- expose the equipment surface from the shared portal navigation
- link order-detail equipment names to the portal equipment detail page
- add portal blueprint coverage for the new navigation path

## Testing
- docker compose -f docker-compose.test-dev.yml exec -T test pytest tests/blueprint/test_portal.py tests/blueprint/test_portal_equipment.py tests/blueprint/test_portal_auth.py tests/unit/services/test_portal_service.py -q