### PR TITLE
Harden unified attachment gallery

### DIFF
--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -14,6 +14,7 @@ from werkzeug.utils import secure_filename
 
 from app.extensions import db
 from app.models.attachment import Attachment
+from app.models.service_order import ServiceOrder
 from app.models.service_order_item import ServiceOrderItem
 
 # Allowed MIME types for upload
@@ -236,8 +237,15 @@ def get_unified_attachments(service_item_id):
 
     # Find all service order items referencing this equipment
     order_items = (
-        ServiceOrderItem.query
-        .filter_by(service_item_id=service_item_id)
+        db.session.query(ServiceOrderItem)
+        .join(ServiceOrder)
+        .filter(ServiceOrderItem.service_item_id == service_item_id)
+        .filter(ServiceOrder.is_deleted == False)  # noqa: E712
+        .order_by(
+            ServiceOrder.date_received.desc(),
+            ServiceOrder.id.desc(),
+            ServiceOrderItem.id.desc(),
+        )
         .all()
     )
 

--- a/app/templates/partials/image_capture.html
+++ b/app/templates/partials/image_capture.html
@@ -262,6 +262,16 @@ function refreshGallery(type, id) {
     if (gallery) {
         htmx.ajax('GET', '/attachments/gallery/' + type + '/' + id, {target: gallery, swap: 'innerHTML'});
     }
+    if (type === 'service_item') {
+        refreshUnifiedGallery(id);
+    }
+}
+
+function refreshUnifiedGallery(id) {
+    const gallery = document.getElementById('unified-gallery-' + id);
+    if (gallery) {
+        htmx.ajax('GET', '/attachments/gallery/unified/' + id, {target: gallery, swap: 'innerHTML'});
+    }
 }
 
 function showError(type, id, msg) {

--- a/tests/blueprint/test_attachment_routes.py
+++ b/tests/blueprint/test_attachment_routes.py
@@ -1,5 +1,7 @@
 """Blueprint tests for attachment routes including unified gallery."""
 
+from datetime import date
+
 import pytest
 
 from tests.factories import (
@@ -77,3 +79,29 @@ class TestUnifiedGalleryEndpoint:
         assert resp.status_code == 200
         assert b"No item photos" in resp.data
         assert b"No service visit photos" in resp.data
+
+    def test_deleted_order_photos_are_hidden(self, app, db_session, logged_in_client):
+        """Deleted service orders should not appear in the unified gallery."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        visible_order = ServiceOrderFactory(date_received=date(2026, 3, 10))
+        deleted_order = ServiceOrderFactory(
+            date_received=date(2026, 3, 11),
+            is_deleted=True,
+        )
+        visible_item = ServiceOrderItemFactory(order=visible_order, service_item=item)
+        deleted_item = ServiceOrderItemFactory(order=deleted_order, service_item=item)
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=visible_item.id,
+        )
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=deleted_item.id,
+        )
+
+        resp = logged_in_client.get(f"/attachments/gallery/unified/{item.id}")
+
+        assert resp.status_code == 200
+        assert visible_order.order_number.encode() in resp.data
+        assert deleted_order.order_number.encode() not in resp.data

--- a/tests/unit/services/test_attachment_service.py
+++ b/tests/unit/services/test_attachment_service.py
@@ -1,5 +1,7 @@
 """Unit tests for attachment service unified gallery function."""
 
+from datetime import date
+
 import pytest
 
 from app.services import attachment_service
@@ -108,3 +110,53 @@ class TestGetUnifiedAttachments:
         direct, order_atts = attachment_service.get_unified_attachments(item.id)
 
         assert len(order_atts) == 0
+
+    def test_excludes_deleted_orders(self, app, db_session):
+        """Attachments from soft-deleted service orders should be hidden."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        visible_order = ServiceOrderFactory(
+            date_received=date(2026, 3, 10),
+        )
+        deleted_order = ServiceOrderFactory(
+            date_received=date(2026, 3, 11),
+            is_deleted=True,
+        )
+        visible_item = ServiceOrderItemFactory(order=visible_order, service_item=item)
+        deleted_item = ServiceOrderItemFactory(order=deleted_order, service_item=item)
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=visible_item.id,
+        )
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=deleted_item.id,
+        )
+
+        _, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert [group["order_item"].id for group in order_atts] == [visible_item.id]
+
+    def test_orders_newest_first(self, app, db_session):
+        """Service-visit groups should follow the same newest-first ordering as history."""
+        _set_session(db_session)
+        item = ServiceItemFactory()
+        older_order = ServiceOrderFactory(date_received=date(2026, 3, 1))
+        newer_order = ServiceOrderFactory(date_received=date(2026, 3, 15))
+        older_item = ServiceOrderItemFactory(order=older_order, service_item=item)
+        newer_item = ServiceOrderItemFactory(order=newer_order, service_item=item)
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=older_item.id,
+        )
+        AttachmentFactory(
+            attachable_type="service_order_item",
+            attachable_id=newer_item.id,
+        )
+
+        _, order_atts = attachment_service.get_unified_attachments(item.id)
+
+        assert [group["order_item"].id for group in order_atts] == [
+            newer_item.id,
+            older_item.id,
+        ]


### PR DESCRIPTION
## Summary
- hide deleted-order attachments from the unified gallery and keep service-visit groups newest-first
- refresh the unified HTMX gallery after uploads and deletes on item pages
- add focused attachment tests for deleted orders and chronology

## Testing
- docker compose -f docker-compose.test-dev.yml up -d test && docker compose -f docker-compose.test-dev.yml exec -T test pytest tests/unit/services/test_attachment_service.py tests/blueprint/test_attachment_routes.py -q