### PR TITLE
Implement modular shipping provider framework

### DIFF
--- a/app/blueprints/orders/shipping.py
+++ b/app/blueprints/orders/shipping.py
@@ -29,15 +29,19 @@ def shipping(id):
     order = get_order(id)
     shipments = shipping_service.get_order_shipments(id)
     shipping_total = shipping_service.get_order_shipping_total(id)
-    provider = shipping_service.get_provider()
-    methods = provider.get_available_methods()
+    providers = shipping_service.get_provider_catalog()
+    default_provider_code = shipping_service.get_workflow_default_provider_code()
 
     return render_template(
         "orders/shipping.html",
         order=order,
         shipments=shipments,
         shipping_total=shipping_total,
-        methods=methods,
+        providers=providers,
+        default_provider_code=default_provider_code,
+        quote_placeholder=_get_quote_placeholder(default_provider_code),
+        default_destination_postal_code=(order.customer.postal_code or ""),
+        default_destination_country=(order.customer.country or "US"),
     )
 
 
@@ -57,14 +61,13 @@ def create_shipment(id):
     length_in = _parse_decimal(request.form.get("length_in"))
     width_in = _parse_decimal(request.form.get("width_in"))
     height_in = _parse_decimal(request.form.get("height_in"))
+    provider_code = request.form.get("provider_code") or None
     shipping_method = request.form.get("shipping_method") or None
+    destination_postal_code = request.form.get("destination_postal_code") or None
+    destination_country = request.form.get("destination_country") or None
     carrier = request.form.get("carrier") or None
     tracking_number = request.form.get("tracking_number") or None
     notes = request.form.get("notes") or None
-
-    if weight_lbs is None or weight_lbs <= 0:
-        flash("Weight is required and must be greater than zero.", "error")
-        return redirect(url_for("orders.shipping", id=id))
 
     try:
         shipping_service.create_shipment(
@@ -74,6 +77,9 @@ def create_shipment(id):
             width_in=width_in,
             height_in=height_in,
             shipping_method=shipping_method,
+            provider_code=provider_code,
+            destination_postal_code=destination_postal_code,
+            destination_country=destination_country,
             carrier=carrier,
             tracking_number=tracking_number,
             notes=notes,
@@ -103,21 +109,56 @@ def shipping_estimate(id):
     Accepts weight_lbs as a query parameter. Returns a styled cost
     fragment for HTMX to swap into the page.
     """
+    get_order(id)
+
+    provider_code = request.args.get("provider_code") or None
+    method = request.args.get("shipping_method") or request.args.get("method")
     weight_lbs = _parse_decimal(request.args.get("weight_lbs"))
-
-    if weight_lbs is None or weight_lbs <= 0:
-        return '<span class="text-muted">Enter weight to estimate cost</span>'
-
     length_in = _parse_decimal(request.args.get("length_in"))
     width_in = _parse_decimal(request.args.get("width_in"))
     height_in = _parse_decimal(request.args.get("height_in"))
-    method = request.args.get("shipping_method") or request.args.get("method")
+    destination_postal_code = request.args.get("destination_postal_code") or None
+    destination_country = request.args.get("destination_country") or None
 
-    cost = shipping_service.estimate_shipping(
-        weight_lbs, length_in, width_in, height_in, method,
+    try:
+        requires_weight = shipping_service.provider_requires_weight(provider_code, method)
+    except ValueError as exc:
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=str(exc),
+        )
+
+    if requires_weight and (weight_lbs is None or weight_lbs <= 0):
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=_get_quote_placeholder(provider_code, method),
+        )
+
+    try:
+        quote = shipping_service.quote_shipping(
+            weight_lbs=weight_lbs,
+            length_in=length_in,
+            width_in=width_in,
+            height_in=height_in,
+            method=method,
+            provider_code=provider_code,
+            destination_postal_code=destination_postal_code,
+            destination_country=destination_country,
+        )
+    except ValueError as exc:
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=str(exc),
+        )
+
+    return render_template(
+        "partials/shipping_quote.html",
+        quote=quote.to_dict(),
+        placeholder_text=_get_quote_placeholder(provider_code, method),
     )
-
-    return f'<span class="text-success fw-bold">${cost:.2f}</span>'
 
 
 # ======================================================================
@@ -203,3 +244,13 @@ def _parse_decimal(value):
         return parsed
     except (InvalidOperation, ValueError, AttributeError):
         return None
+
+
+def _get_quote_placeholder(provider_code=None, shipping_method=None):
+    """Return contextual placeholder text for the selected provider."""
+    try:
+        if shipping_service.provider_requires_weight(provider_code, shipping_method):
+            return "Enter weight and optional dimensions to estimate shipping."
+    except ValueError:
+        pass
+    return "Local pickup stays at $0.00 and does not require package weight."

--- a/app/blueprints/tools.py
+++ b/app/blueprints/tools.py
@@ -1,6 +1,11 @@
 """Tools blueprint — utility calculators and reference tools for dive service."""
-from flask import Blueprint, render_template
+
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, render_template, request
 from flask_security import login_required
+
+from app.services import shipping_service
 
 tools_bp = Blueprint("tools", __name__, url_prefix="/tools")
 
@@ -33,6 +38,74 @@ def pricing_calculator():
     return render_template("tools/pricing_calculator.html")
 
 
+@tools_bp.route("/shipping-calculator")
+@login_required
+def shipping_calculator():
+    """Standalone shipping calculator using the shared shipping framework."""
+    default_provider_code = shipping_service.get_workflow_default_provider_code()
+    return render_template(
+        "tools/shipping_calculator.html",
+        providers=shipping_service.get_provider_catalog(),
+        default_provider_code=default_provider_code,
+        quote_placeholder=_get_quote_placeholder(default_provider_code),
+        default_destination_country="US",
+    )
+
+
+@tools_bp.route("/shipping-calculator/estimate")
+@login_required
+def shipping_calculator_estimate():
+    """Return a provider-aware quote fragment for the tools calculator."""
+    provider_code = request.args.get("provider_code") or None
+    method = request.args.get("shipping_method") or request.args.get("method")
+    weight_lbs = _parse_decimal(request.args.get("weight_lbs"))
+    length_in = _parse_decimal(request.args.get("length_in"))
+    width_in = _parse_decimal(request.args.get("width_in"))
+    height_in = _parse_decimal(request.args.get("height_in"))
+    destination_postal_code = request.args.get("destination_postal_code") or None
+    destination_country = request.args.get("destination_country") or None
+
+    try:
+        requires_weight = shipping_service.provider_requires_weight(provider_code, method)
+    except ValueError as exc:
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=str(exc),
+        )
+
+    if requires_weight and (weight_lbs is None or weight_lbs <= 0):
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=_get_quote_placeholder(provider_code, method),
+        )
+
+    try:
+        quote = shipping_service.quote_shipping(
+            weight_lbs=weight_lbs,
+            length_in=length_in,
+            width_in=width_in,
+            height_in=height_in,
+            method=method,
+            provider_code=provider_code,
+            destination_postal_code=destination_postal_code,
+            destination_country=destination_country,
+        )
+    except ValueError as exc:
+        return render_template(
+            "partials/shipping_quote.html",
+            quote=None,
+            placeholder_text=str(exc),
+        )
+
+    return render_template(
+        "partials/shipping_quote.html",
+        quote=quote.to_dict(),
+        placeholder_text=_get_quote_placeholder(provider_code, method),
+    )
+
+
 @tools_bp.route("/leak-test-log")
 @login_required
 def leak_test_log():
@@ -52,3 +125,26 @@ def valve_reference():
 def converter():
     """Unit converter for dive service measurements."""
     return render_template("tools/converter.html")
+
+
+def _parse_decimal(value):
+    """Parse a string to Decimal, returning None on failure."""
+    if not value:
+        return None
+    try:
+        parsed = Decimal(value.strip())
+        if not parsed.is_finite():
+            return None
+        return parsed
+    except (InvalidOperation, ValueError, AttributeError):
+        return None
+
+
+def _get_quote_placeholder(provider_code=None, shipping_method=None):
+    """Return contextual placeholder text for the selected provider."""
+    try:
+        if shipping_service.provider_requires_weight(provider_code, shipping_method):
+            return "Enter weight and optional dimensions to estimate shipping."
+    except ValueError:
+        pass
+    return "Local pickup stays at $0.00 and does not require package weight."

--- a/app/models/shipment.py
+++ b/app/models/shipment.py
@@ -29,8 +29,10 @@ class Shipment(TimestampMixin, AuditMixin, db.Model):
     height_in = db.Column(db.Numeric(8, 2), nullable=True)
 
     # Shipping details
+    provider_code = db.Column(db.String(50), nullable=True)
     shipping_method = db.Column(db.String(100), nullable=True)
     shipping_cost = db.Column(db.Numeric(10, 2), nullable=True)
+    quote_metadata = db.Column(db.JSON, nullable=True, default=dict)
     tracking_number = db.Column(db.String(255), nullable=True)
     carrier = db.Column(db.String(100), nullable=True)
     status = db.Column(db.String(50), default="pending", nullable=False)

--- a/app/services/shipping_service.py
+++ b/app/services/shipping_service.py
@@ -1,18 +1,10 @@
-"""Shipping service layer — rate calculation and shipment CRUD.
+"""Shipping service layer - rate calculation, quote metadata, and shipment CRUD."""
 
-Provides a pluggable provider framework for shipping rate calculations
-and functions to create, update, and query shipment records.
-
-Future integration note: When generating invoices from orders, shipping
-costs should be added as a line item on the invoice.  This integration
-is not yet implemented — currently shipping is tracked separately from
-invoices.  To add it, modify invoice_service.generate_from_order() to
-query order.shipments and include a "Shipping" line item with the total
-shipping cost.
-"""
-
+from copy import deepcopy
 import json
-from decimal import Decimal
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
 
 from flask import abort
 
@@ -21,10 +13,6 @@ from app.models.shipment import Shipment, VALID_STATUSES
 from app.services import audit_service, config_service
 
 
-# ---------------------------------------------------------------------------
-# Default flat-rate tiers (used when SystemConfig has no override)
-# ---------------------------------------------------------------------------
-
 DEFAULT_FLAT_RATE_TIERS = [
     {"max_weight": 5, "rate": "9.99"},
     {"max_weight": 15, "rate": "14.99"},
@@ -32,99 +20,367 @@ DEFAULT_FLAT_RATE_TIERS = [
     {"max_weight": 9999, "rate": "39.99"},
 ]
 
+DEFAULT_ENABLED_PROVIDER_CODES = [
+    "usps",
+    "ups",
+    "fedex",
+    "dhl",
+    "local_pickup",
+    "flat_rate",
+]
+
+DEFAULT_CARRIER_PROFILES = {
+    "usps": {
+        "name": "USPS",
+        "description": "Mock-ready USPS services with dimensional pricing support.",
+        "base_rate": "5.25",
+        "per_lb_rate": "0.78",
+        "dimensional_divisor": "166",
+        "oversize_threshold_cuin": "1728",
+        "oversize_surcharge": "3.50",
+        "methods": [
+            {
+                "code": "usps_ground_advantage",
+                "name": "Ground Advantage",
+                "description": "Economy ground delivery for domestic shipments.",
+                "delivery_window": "2-5 business days",
+                "multiplier": "1.00",
+                "minimum_charge": "6.95",
+            },
+            {
+                "code": "usps_priority_mail",
+                "name": "Priority Mail",
+                "description": "Priority mail with faster delivery targets.",
+                "delivery_window": "1-3 business days",
+                "multiplier": "1.24",
+                "minimum_charge": "9.95",
+            },
+            {
+                "code": "usps_priority_mail_express",
+                "name": "Priority Mail Express",
+                "description": "Fastest USPS mock quote option.",
+                "delivery_window": "1-2 business days",
+                "multiplier": "1.68",
+                "minimum_charge": "18.95",
+            },
+        ],
+    },
+    "ups": {
+        "name": "UPS",
+        "description": "Mock UPS rates with heavier package bias and air upgrades.",
+        "base_rate": "6.40",
+        "per_lb_rate": "0.92",
+        "dimensional_divisor": "139",
+        "oversize_threshold_cuin": "1944",
+        "oversize_surcharge": "5.00",
+        "methods": [
+            {
+                "code": "ups_ground",
+                "name": "UPS Ground",
+                "description": "Standard UPS ground service.",
+                "delivery_window": "1-5 business days",
+                "multiplier": "1.00",
+                "minimum_charge": "8.95",
+            },
+            {
+                "code": "ups_three_day_select",
+                "name": "3 Day Select",
+                "description": "Mid-speed UPS air service.",
+                "delivery_window": "3 business days",
+                "multiplier": "1.28",
+                "minimum_charge": "12.95",
+            },
+            {
+                "code": "ups_second_day_air",
+                "name": "2nd Day Air",
+                "description": "Faster UPS air delivery.",
+                "delivery_window": "2 business days",
+                "multiplier": "1.52",
+                "minimum_charge": "16.95",
+            },
+            {
+                "code": "ups_next_day_air",
+                "name": "Next Day Air",
+                "description": "Highest-priority UPS service.",
+                "delivery_window": "Next business day",
+                "multiplier": "2.05",
+                "minimum_charge": "26.95",
+            },
+        ],
+    },
+    "fedex": {
+        "name": "FedEx",
+        "description": "Mock FedEx services tuned for dimensional packages.",
+        "base_rate": "6.10",
+        "per_lb_rate": "0.89",
+        "dimensional_divisor": "139",
+        "oversize_threshold_cuin": "1944",
+        "oversize_surcharge": "4.50",
+        "methods": [
+            {
+                "code": "fedex_ground",
+                "name": "FedEx Ground",
+                "description": "Standard FedEx ground delivery.",
+                "delivery_window": "1-5 business days",
+                "multiplier": "1.00",
+                "minimum_charge": "8.49",
+            },
+            {
+                "code": "fedex_express_saver",
+                "name": "Express Saver",
+                "description": "Three-day express delivery.",
+                "delivery_window": "3 business days",
+                "multiplier": "1.31",
+                "minimum_charge": "12.49",
+            },
+            {
+                "code": "fedex_two_day",
+                "name": "2Day",
+                "description": "FedEx two-day delivery.",
+                "delivery_window": "2 business days",
+                "multiplier": "1.57",
+                "minimum_charge": "17.49",
+            },
+            {
+                "code": "fedex_standard_overnight",
+                "name": "Standard Overnight",
+                "description": "Overnight delivery option.",
+                "delivery_window": "Next business day",
+                "multiplier": "2.10",
+                "minimum_charge": "27.49",
+            },
+        ],
+    },
+    "dhl": {
+        "name": "DHL",
+        "description": "Mock DHL services suited for international-capable workflows.",
+        "base_rate": "7.25",
+        "per_lb_rate": "1.02",
+        "dimensional_divisor": "139",
+        "oversize_threshold_cuin": "1728",
+        "oversize_surcharge": "6.25",
+        "methods": [
+            {
+                "code": "dhl_ground_connect",
+                "name": "Ground Connect",
+                "description": "Economy ground-style DHL mock quote.",
+                "delivery_window": "2-6 business days",
+                "multiplier": "1.00",
+                "minimum_charge": "9.95",
+            },
+            {
+                "code": "dhl_express_worldwide",
+                "name": "Express Worldwide",
+                "description": "Fast DHL express service.",
+                "delivery_window": "1-3 business days",
+                "multiplier": "1.74",
+                "minimum_charge": "21.95",
+            },
+        ],
+    },
+}
+
 MAX_TEXT_LENGTHS = {
+    "provider_code": 50,
     "shipping_method": 100,
     "carrier": 100,
     "tracking_number": 255,
+    "destination_postal_code": 20,
+    "destination_country": 100,
 }
 MAX_DECIMAL_VALUE = Decimal("999999.99")
+MONEY_QUANTUM = Decimal("0.01")
+MEASUREMENT_QUANTUM = Decimal("0.01")
 NON_CANCELLED_STATUSES = tuple(
     status for status in VALID_STATUSES if status != "cancelled"
 )
 AUDIT_NOTES_MAX_LENGTH = 500
 
 
-# ---------------------------------------------------------------------------
-# Provider framework
-# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ShippingQuoteRequest:
+    """Normalized inputs used by provider adapters."""
+
+    weight_lbs: Decimal | None = None
+    length_in: Decimal | None = None
+    width_in: Decimal | None = None
+    height_in: Decimal | None = None
+    provider_code: str | None = None
+    method_code: str | None = None
+    destination_postal_code: str | None = None
+    destination_country: str | None = None
+
+
+@dataclass
+class ShippingQuote:
+    """Carrier/provider quote with normalized metadata."""
+
+    provider_code: str
+    provider_name: str
+    method_code: str
+    method_name: str
+    amount: Decimal
+    currency: str = "USD"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation for routes and templates."""
+        return {
+            "provider_code": self.provider_code,
+            "provider_name": self.provider_name,
+            "method_code": self.method_code,
+            "method_name": self.method_name,
+            "amount": _format_decimal(self.amount),
+            "amount_display": f"${self.amount:.2f}",
+            "currency": self.currency,
+            "metadata": _json_safe(self.metadata),
+        }
+
+    def to_record_metadata(self) -> dict[str, Any]:
+        """Return compact metadata for persistence on Shipment rows."""
+        payload = self.to_dict()
+        payload["quote_captured"] = True
+        return payload
+
 
 class ShippingProvider:
-    """Base class for shipping rate providers.
+    """Base class for pluggable shipping providers."""
 
-    Subclass this and implement the three methods to add new carriers
-    or rate calculation strategies.
-    """
+    code = "base"
+    name = "Base Provider"
+    description = ""
 
     def get_name(self):
-        """Return the human-readable provider name."""
-        raise NotImplementedError
+        return self.name
 
-    def calculate_rate(self, weight_lbs, length_in=None, width_in=None,
-                       height_in=None, method=None):
-        """Return estimated shipping cost as a Decimal.
-
-        Parameters
-        ----------
-        weight_lbs : Decimal
-            Package weight in pounds.
-        length_in, width_in, height_in : Decimal, optional
-            Package dimensions in inches (not used by all providers).
-        method : str, optional
-            Shipping method code.
-
-        Returns
-        -------
-        Decimal
-            The calculated shipping rate.
-        """
-        raise NotImplementedError
+    def get_description(self):
+        return self.description
 
     def get_available_methods(self):
-        """Return a list of available shipping methods.
-
-        Each method is a dict with keys: code, name, description.
-        """
         raise NotImplementedError
+
+    def get_default_method(self):
+        methods = self.get_available_methods()
+        if not methods:
+            raise ValueError(f"Provider {self.code} has no configured methods.")
+        return methods[0]
+
+    def get_method(self, method_code=None):
+        if not method_code:
+            return self.get_default_method()
+        for method in self.get_available_methods():
+            if method["code"] == method_code:
+                return method
+        raise ValueError(
+            f"Shipping method '{method_code}' is not available for provider '{self.code}'."
+        )
+
+    def requires_weight(self, method_code=None):
+        return True
+
+    def quote(self, request: ShippingQuoteRequest) -> ShippingQuote:
+        raise NotImplementedError
+
+    def calculate_rate(
+        self,
+        weight_lbs,
+        length_in=None,
+        width_in=None,
+        height_in=None,
+        method=None,
+    ):
+        """Retain the legacy cost-only API for existing callers and tests."""
+        quote = self.quote(
+            ShippingQuoteRequest(
+                weight_lbs=_validate_decimal(weight_lbs, "weight_lbs", allow_zero=False),
+                length_in=_normalize_dimension(length_in, "length_in"),
+                width_in=_normalize_dimension(width_in, "width_in"),
+                height_in=_normalize_dimension(height_in, "height_in"),
+                provider_code=self.code,
+                method_code=method,
+            )
+        )
+        return quote.amount
+
+    def as_catalog_dict(self):
+        methods = []
+        for method in self.get_available_methods():
+            method_entry = dict(method)
+            method_entry.setdefault("provider_code", self.code)
+            methods.append(_json_safe(method_entry))
+        return {
+            "code": self.code,
+            "name": self.get_name(),
+            "description": self.get_description(),
+            "default_method_code": self.get_default_method()["code"],
+            "requires_weight": self.requires_weight(self.get_default_method()["code"]),
+            "methods": methods,
+        }
 
 
 class FlatRateProvider(ShippingProvider):
-    """Flat-rate shipping based on weight tiers from SystemConfig."""
+    """Flat-rate shipping based on weight tiers from config."""
 
-    def get_name(self):
-        return "Flat Rate"
-
-    def calculate_rate(self, weight_lbs, length_in=None, width_in=None,
-                       height_in=None, method=None):
-        """Calculate flat-rate shipping cost based on weight tiers.
-
-        Tiers are read from SystemConfig key ``shipping.flat_rate_tiers``.
-        Falls back to DEFAULT_FLAT_RATE_TIERS if not configured.
-        """
-        tiers = self._get_tiers()
-        weight = Decimal(str(weight_lbs))
-
-        for tier in sorted(tiers, key=lambda t: t["max_weight"]):
-            if weight <= Decimal(str(tier["max_weight"])):
-                return Decimal(str(tier["rate"]))
-
-        # If weight exceeds all tiers, use the highest tier rate
-        if tiers:
-            highest = max(tiers, key=lambda t: t["max_weight"])
-            return Decimal(str(highest["rate"]))
-
-        return Decimal("0.00")
+    code = "flat_rate"
+    name = "Flat Rate"
+    description = "Fallback flat-rate pricing by package weight."
 
     def get_available_methods(self):
         return [
             {
                 "code": "flat_rate",
                 "name": "Flat Rate Shipping",
-                "description": "Standard shipping by weight",
+                "description": "Standard fallback shipping by weight tier.",
+                "delivery_window": "2-5 business days",
             }
         ]
 
+    def quote(self, request: ShippingQuoteRequest) -> ShippingQuote:
+        method = self.get_method(request.method_code)
+        if request.weight_lbs is None:
+            raise ValueError("Weight is required for the selected shipping provider.")
+
+        matched_tier = None
+        tiers = self._get_tiers()
+        weight = request.weight_lbs
+        amount = Decimal("0.00")
+
+        for tier in sorted(tiers, key=lambda tier: Decimal(str(tier["max_weight"]))):
+            if weight <= Decimal(str(tier["max_weight"])):
+                matched_tier = tier
+                amount = Decimal(str(tier["rate"]))
+                break
+
+        if matched_tier is None and tiers:
+            matched_tier = max(tiers, key=lambda tier: Decimal(str(tier["max_weight"])))
+            amount = Decimal(str(matched_tier["rate"]))
+
+        metadata = {
+            "quote_source": "flat_rate_schedule",
+            "estimated_delivery_days": method.get("delivery_window"),
+            "billable_weight_lbs": _format_decimal(weight),
+            "tier_label": (
+                f"Up to {_format_decimal(matched_tier['max_weight'])} lbs"
+                if matched_tier is not None
+                else None
+            ),
+            "destination_postal_code": request.destination_postal_code,
+            "destination_country": request.destination_country,
+            "destination_summary": _format_destination_summary(
+                request.destination_postal_code,
+                request.destination_country,
+            ),
+        }
+        return ShippingQuote(
+            provider_code=self.code,
+            provider_name=self.get_name(),
+            method_code=method["code"],
+            method_name=method["name"],
+            amount=_quantize_money(amount),
+            metadata=metadata,
+        )
+
     def _get_tiers(self):
-        """Load tiers from SystemConfig or fall back to defaults."""
         raw = config_service.get_config("shipping.flat_rate_tiers")
         if raw:
             try:
@@ -134,45 +390,337 @@ class FlatRateProvider(ShippingProvider):
         return DEFAULT_FLAT_RATE_TIERS
 
 
-# ---------------------------------------------------------------------------
-# Provider registry
-# ---------------------------------------------------------------------------
+class LocalPickupProvider(ShippingProvider):
+    """Zero-cost local pickup option."""
 
-def get_provider():
-    """Return the active shipping provider.
+    code = "local_pickup"
+    name = "Local Pickup"
+    description = "Customer pickup at the shop with zero shipping cost."
 
-    Currently returns FlatRateProvider.  Extend this function to support
-    multiple providers selected via SystemConfig.
-    """
-    return FlatRateProvider()
+    def get_available_methods(self):
+        return [
+            {
+                "code": "local_pickup",
+                "name": "Customer Pickup",
+                "description": "No carrier shipment. Customer collects locally.",
+                "delivery_window": "Ready when service is complete",
+            }
+        ]
+
+    def requires_weight(self, method_code=None):
+        return False
+
+    def quote(self, request: ShippingQuoteRequest) -> ShippingQuote:
+        method = self.get_method(request.method_code)
+        metadata = {
+            "quote_source": "local_pickup",
+            "estimated_delivery_days": method.get("delivery_window"),
+            "pickup_message": "No carrier charge will be added for local pickup.",
+            "zero_cost": True,
+            "destination_postal_code": request.destination_postal_code,
+            "destination_country": request.destination_country,
+            "destination_summary": _format_destination_summary(
+                request.destination_postal_code,
+                request.destination_country,
+            ),
+        }
+        return ShippingQuote(
+            provider_code=self.code,
+            provider_name=self.get_name(),
+            method_code=method["code"],
+            method_name=method["name"],
+            amount=Decimal("0.00"),
+            metadata=metadata,
+        )
 
 
-# ---------------------------------------------------------------------------
-# Rate estimation
-# ---------------------------------------------------------------------------
+class FormulaCarrierProvider(ShippingProvider):
+    """Config-driven mock carrier adapter with room for live API overrides."""
 
-def estimate_shipping(weight_lbs, length_in=None, width_in=None,
-                      height_in=None, method=None):
-    """Calculate estimated shipping cost using the active provider.
+    credential_keys = ()
 
-    Returns
-    -------
-    Decimal
-        The estimated shipping cost, or Decimal("0.00") if weight is
-        not provided.
-    """
-    if weight_lbs is None:
-        return Decimal("0.00")
+    def get_name(self):
+        return self._get_profile()["name"]
 
-    provider = get_provider()
-    return provider.calculate_rate(
-        weight_lbs, length_in, width_in, height_in, method,
+    def get_description(self):
+        return self._get_profile()["description"]
+
+    def get_available_methods(self):
+        return self._get_profile()["methods"]
+
+    def quote(self, request: ShippingQuoteRequest) -> ShippingQuote:
+        method = self.get_method(request.method_code)
+        if request.weight_lbs is None:
+            raise ValueError("Weight is required for the selected shipping provider.")
+        return self._build_formula_quote(request, method)
+
+    def credentials_configured(self):
+        return all(
+            bool(config_service.get_config(key))
+            for key in self.credential_keys
+        ) if self.credential_keys else False
+
+    def _get_profile(self):
+        profile = deepcopy(DEFAULT_CARRIER_PROFILES[self.code])
+        overrides = _get_provider_overrides().get(self.code, {})
+        if not isinstance(overrides, dict):
+            return profile
+
+        methods = {method["code"]: method for method in profile.get("methods", [])}
+        override_methods = overrides.get("methods", [])
+        if isinstance(override_methods, list):
+            for override in override_methods:
+                if not isinstance(override, dict) or not override.get("code"):
+                    continue
+                base_method = deepcopy(methods.get(override["code"], {}))
+                base_method.update(override)
+                methods[override["code"]] = base_method
+
+        for key, value in overrides.items():
+            if key == "methods":
+                continue
+            profile[key] = value
+
+        profile["methods"] = list(methods.values())
+        return profile
+
+    def _build_formula_quote(self, request: ShippingQuoteRequest, method: dict[str, Any]):
+        profile = self._get_profile()
+        weight = request.weight_lbs
+        divisor = _decimal_or_zero(profile.get("dimensional_divisor"))
+        volume = _package_volume(request.length_in, request.width_in, request.height_in)
+        dimensional_weight = weight
+        if volume is not None and divisor > 0:
+            dimensional_weight = _quantize_measure(volume / divisor)
+        billable_weight = max(weight, dimensional_weight)
+
+        base_rate = _decimal_or_zero(profile.get("base_rate"))
+        per_lb_rate = _decimal_or_zero(profile.get("per_lb_rate"))
+        oversize_threshold = _decimal_or_zero(profile.get("oversize_threshold_cuin"))
+        oversize_surcharge = Decimal("0.00")
+        if volume is not None and oversize_threshold > 0 and volume > oversize_threshold:
+            oversize_surcharge = _decimal_or_zero(profile.get("oversize_surcharge"))
+        destination_country = request.destination_country or "US"
+        destination_postal_code = request.destination_postal_code
+        international = destination_country.upper() not in {"US", "USA", "UNITED STATES"}
+        destination_surcharge = Decimal("0.00")
+        if international:
+            destination_surcharge = Decimal("12.00")
+        elif destination_postal_code and len(destination_postal_code.replace(" ", "")) > 5:
+            destination_surcharge = Decimal("1.50")
+
+        multiplier = _decimal_or_zero(method.get("multiplier") or "1.00")
+        minimum_charge = _decimal_or_zero(method.get("minimum_charge"))
+        amount = (
+            base_rate
+            + (billable_weight * per_lb_rate)
+            + oversize_surcharge
+            + destination_surcharge
+        ) * multiplier
+        amount = max(_quantize_money(amount), _quantize_money(minimum_charge))
+
+        metadata = {
+            "quote_source": "mock_formula",
+            "estimated_delivery_days": method.get("delivery_window"),
+            "billable_weight_lbs": _format_decimal(billable_weight),
+            "dimensional_weight_lbs": (
+                _format_decimal(dimensional_weight)
+                if dimensional_weight != weight or volume is not None
+                else None
+            ),
+            "oversize_applied": oversize_surcharge > 0,
+            "credentials_configured": self.credentials_configured(),
+            "live_adapter_ready": False,
+            "destination_postal_code": destination_postal_code,
+            "destination_country": destination_country,
+            "destination_summary": _format_destination_summary(
+                destination_postal_code,
+                destination_country,
+            ),
+            "international": international,
+            "destination_surcharge": (
+                _format_decimal(destination_surcharge)
+                if destination_surcharge > 0
+                else None
+            ),
+        }
+        return ShippingQuote(
+            provider_code=self.code,
+            provider_name=self.get_name(),
+            method_code=method["code"],
+            method_name=method["name"],
+            amount=amount,
+            metadata=metadata,
+        )
+
+
+class USPSProvider(FormulaCarrierProvider):
+    code = "usps"
+    credential_keys = ("shipping.usps.client_id", "shipping.usps.client_secret")
+
+
+class UPSProvider(FormulaCarrierProvider):
+    code = "ups"
+    credential_keys = ("shipping.ups.client_id", "shipping.ups.client_secret")
+
+
+class FedExProvider(FormulaCarrierProvider):
+    code = "fedex"
+    credential_keys = ("shipping.fedex.api_key", "shipping.fedex.api_secret")
+
+
+class DHLProvider(FormulaCarrierProvider):
+    code = "dhl"
+    credential_keys = ("shipping.dhl.api_key", "shipping.dhl.api_secret")
+
+
+PROVIDER_REGISTRY = {
+    "flat_rate": FlatRateProvider,
+    "local_pickup": LocalPickupProvider,
+    "usps": USPSProvider,
+    "ups": UPSProvider,
+    "fedex": FedExProvider,
+    "dhl": DHLProvider,
+}
+
+
+def get_enabled_provider_codes():
+    """Return enabled providers in display order."""
+    raw = config_service.get_config("shipping.enabled_providers")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            raw = [part.strip() for part in raw.split(",") if part.strip()]
+
+    if not isinstance(raw, list):
+        raw = DEFAULT_ENABLED_PROVIDER_CODES
+
+    enabled_codes = []
+    for code in raw:
+        if not isinstance(code, str):
+            continue
+        normalized = code.strip().lower()
+        if normalized in PROVIDER_REGISTRY and normalized not in enabled_codes:
+            enabled_codes.append(normalized)
+
+    if not enabled_codes:
+        enabled_codes = list(DEFAULT_ENABLED_PROVIDER_CODES)
+
+    if "local_pickup" in enabled_codes:
+        enabled_codes = ["local_pickup"] + [
+            code for code in enabled_codes if code != "local_pickup"
+        ]
+    else:
+        enabled_codes.insert(0, "local_pickup")
+
+    if "flat_rate" not in enabled_codes:
+        enabled_codes.append("flat_rate")
+
+    return enabled_codes
+
+
+def get_provider_catalog():
+    """Return provider and method metadata for UI rendering."""
+    catalog = []
+    for code in get_enabled_provider_codes():
+        catalog.append(get_provider(code).as_catalog_dict())
+    return catalog
+
+
+def get_default_provider_code():
+    """Return the configured default provider or a safe fallback."""
+    enabled_codes = get_enabled_provider_codes()
+    configured = config_service.get_config("shipping.default_provider")
+    if isinstance(configured, str):
+        normalized = configured.strip().lower()
+        if normalized in enabled_codes:
+            return normalized
+    if "flat_rate" in enabled_codes:
+        return "flat_rate"
+    return enabled_codes[0]
+
+
+def get_workflow_default_provider_code():
+    """Return the UI default provider for quote-first workflows."""
+    enabled_codes = get_enabled_provider_codes()
+    if "local_pickup" in enabled_codes:
+        return "local_pickup"
+    return get_default_provider_code()
+
+
+def get_provider(provider_code=None):
+    """Return a provider instance by code, or the default provider."""
+    normalized = _normalize_provider_code(provider_code)
+    if normalized is None:
+        normalized = get_default_provider_code()
+    if normalized not in get_enabled_provider_codes():
+        raise ValueError(f"Shipping provider is disabled: {normalized}")
+    provider_cls = PROVIDER_REGISTRY.get(normalized)
+    if provider_cls is None:
+        raise ValueError(f"Unknown shipping provider: {provider_code}")
+    return provider_cls()
+
+
+def provider_requires_weight(provider_code=None, method=None):
+    """Return whether the selected provider/method requires weight input."""
+    resolved_code = _resolve_provider_code(provider_code, method)
+    provider = get_provider(resolved_code)
+    method_code = method or provider.get_default_method()["code"]
+    return provider.requires_weight(method_code)
+
+
+def quote_shipping(
+    weight_lbs=None,
+    length_in=None,
+    width_in=None,
+    height_in=None,
+    method=None,
+    provider_code=None,
+    destination_postal_code=None,
+    destination_country=None,
+):
+    """Return a normalized shipping quote for the selected provider."""
+    prepared = _prepare_quote_request(
+        weight_lbs=weight_lbs,
+        length_in=length_in,
+        width_in=width_in,
+        height_in=height_in,
+        shipping_method=method,
+        provider_code=provider_code,
+        destination_postal_code=destination_postal_code,
+        destination_country=destination_country,
     )
+    return prepared["quote"]
 
 
-# ---------------------------------------------------------------------------
-# Shipment CRUD
-# ---------------------------------------------------------------------------
+def estimate_shipping(
+    weight_lbs,
+    length_in=None,
+    width_in=None,
+    height_in=None,
+    method=None,
+    provider_code=None,
+    destination_postal_code=None,
+    destination_country=None,
+):
+    """Retain the cost-only estimator used by order/invoice integrations."""
+    try:
+        return quote_shipping(
+            weight_lbs=weight_lbs,
+            length_in=length_in,
+            width_in=width_in,
+            height_in=height_in,
+            method=method,
+            provider_code=provider_code,
+            destination_postal_code=destination_postal_code,
+            destination_country=destination_country,
+        ).amount
+    except ValueError as exc:
+        if "Weight is required" in str(exc):
+            return Decimal("0.00")
+        raise
+
 
 def create_shipment(
     order_id,
@@ -181,6 +729,9 @@ def create_shipment(
     width_in=None,
     height_in=None,
     shipping_method=None,
+    provider_code=None,
+    destination_postal_code=None,
+    destination_country=None,
     carrier=None,
     tracking_number=None,
     notes=None,
@@ -188,45 +739,34 @@ def create_shipment(
     ip_address=None,
     user_agent=None,
 ):
-    """Create a new shipment record for a service order.
-
-    Automatically calculates shipping cost based on the active provider
-    if weight is provided.
-
-    Returns
-    -------
-    Shipment
-        The newly created shipment.
-    """
-    shipping_method = _clean_text(
-        shipping_method or "flat_rate",
-        "shipping_method",
-    )
+    """Create a new shipment record for a service order."""
     carrier = _clean_text(carrier, "carrier")
     tracking_number = _clean_text(tracking_number, "tracking_number")
     notes = notes.strip() if isinstance(notes, str) and notes.strip() else None
 
-    weight_lbs = _validate_decimal(weight_lbs, "weight_lbs", allow_zero=False)
-    length_in = _validate_decimal(length_in, "length_in")
-    width_in = _validate_decimal(width_in, "width_in")
-    height_in = _validate_decimal(height_in, "height_in")
-
-    # Calculate cost if weight is provided
-    cost = Decimal("0.00")
-    if weight_lbs is not None:
-        cost = estimate_shipping(
-            weight_lbs, length_in, width_in, height_in, shipping_method,
-        )
-
-    shipment = Shipment(
-        order_id=order_id,
+    prepared = _prepare_quote_request(
         weight_lbs=weight_lbs,
         length_in=length_in,
         width_in=width_in,
         height_in=height_in,
         shipping_method=shipping_method,
-        shipping_cost=cost,
-        carrier=carrier,
+        provider_code=provider_code,
+        destination_postal_code=destination_postal_code,
+        destination_country=destination_country,
+    )
+    quote = prepared["quote"]
+
+    shipment = Shipment(
+        order_id=order_id,
+        provider_code=prepared["provider_code"],
+        weight_lbs=prepared["weight_lbs"],
+        length_in=prepared["length_in"],
+        width_in=prepared["width_in"],
+        height_in=prepared["height_in"],
+        shipping_method=prepared["shipping_method"],
+        shipping_cost=quote.amount,
+        quote_metadata=quote.to_record_metadata(),
+        carrier=carrier or quote.provider_name,
         tracking_number=tracking_number,
         notes=notes,
         status="pending",
@@ -246,7 +786,7 @@ def create_shipment(
             additional_data=_shipment_audit_data(shipment),
         )
     except Exception:
-        pass  # Audit logging must never break the main flow
+        pass
 
     return shipment
 
@@ -258,24 +798,32 @@ def update_shipment(
     user_agent=None,
     **kwargs,
 ):
-    """Update a shipment record.
-
-    Accepted kwargs: tracking_number, carrier, status, notes,
-    weight_lbs, length_in, width_in, height_in, shipping_method.
-
-    If weight changes, shipping cost is recalculated.
-
-    Returns
-    -------
-    Shipment
-        The updated shipment.
-    """
+    """Update a shipment record."""
     shipment = get_shipment(shipment_id)
 
     allowed_fields = {
-        "tracking_number", "carrier", "status", "notes",
-        "weight_lbs", "length_in", "width_in", "height_in",
+        "tracking_number",
+        "carrier",
+        "status",
+        "notes",
+        "weight_lbs",
+        "length_in",
+        "width_in",
+        "height_in",
+        "provider_code",
         "shipping_method",
+        "destination_postal_code",
+        "destination_country",
+    }
+    quote_fields = {
+        "weight_lbs",
+        "length_in",
+        "width_in",
+        "height_in",
+        "provider_code",
+        "shipping_method",
+        "destination_postal_code",
+        "destination_country",
     }
 
     old_values = {}
@@ -283,31 +831,61 @@ def update_shipment(
     if status is not None and status not in VALID_STATUSES:
         raise ValueError(f"Invalid shipment status: {status}")
 
-    for key, value in kwargs.items():
-        if key in allowed_fields:
-            if key in {"shipping_method", "carrier", "tracking_number"}:
-                value = _clean_text(value, key)
-            elif key in {"weight_lbs", "length_in", "width_in", "height_in"}:
-                value = _validate_decimal(
-                    value,
-                    key,
-                    allow_zero=(key != "weight_lbs"),
-                )
-            elif key == "notes":
-                value = value.strip() if isinstance(value, str) and value.strip() else None
+    for field_name in {"tracking_number", "carrier", "notes", "status"}:
+        if field_name not in kwargs or field_name not in allowed_fields:
+            continue
+        old_values[field_name] = getattr(shipment, field_name)
+        value = kwargs[field_name]
+        if field_name in {"tracking_number", "carrier"}:
+            value = _clean_text(value, field_name)
+        elif field_name == "notes":
+            value = value.strip() if isinstance(value, str) and value.strip() else None
+        setattr(shipment, field_name, value)
 
-            old_values[key] = getattr(shipment, key)
-            setattr(shipment, key, value)
-
-    # Recalculate cost if weight changed
-    if "weight_lbs" in kwargs and kwargs["weight_lbs"] is not None:
-        shipment.shipping_cost = estimate_shipping(
-            shipment.weight_lbs,
-            shipment.length_in,
-            shipment.width_in,
-            shipment.height_in,
-            shipment.shipping_method,
+    if quote_fields.intersection(kwargs):
+        quote_metadata = shipment.quote_metadata or {}
+        quote_meta_detail = (
+            quote_metadata.get("metadata", {})
+            if isinstance(quote_metadata, dict)
+            else {}
         )
+        prepared = _prepare_quote_request(
+            weight_lbs=kwargs.get("weight_lbs", shipment.weight_lbs),
+            length_in=kwargs.get("length_in", shipment.length_in),
+            width_in=kwargs.get("width_in", shipment.width_in),
+            height_in=kwargs.get("height_in", shipment.height_in),
+            shipping_method=kwargs.get("shipping_method", shipment.shipping_method),
+            provider_code=kwargs.get("provider_code", shipment.provider_code),
+            destination_postal_code=kwargs.get(
+                "destination_postal_code",
+                quote_meta_detail.get("destination_postal_code"),
+            ),
+            destination_country=kwargs.get(
+                "destination_country",
+                quote_meta_detail.get("destination_country"),
+            ),
+        )
+        quote = prepared["quote"]
+        for field_name in (
+            "provider_code",
+            "shipping_method",
+            "weight_lbs",
+            "length_in",
+            "width_in",
+            "height_in",
+            "shipping_cost",
+            "quote_metadata",
+        ):
+            old_values.setdefault(field_name, getattr(shipment, field_name))
+
+        shipment.provider_code = prepared["provider_code"]
+        shipment.shipping_method = prepared["shipping_method"]
+        shipment.weight_lbs = prepared["weight_lbs"]
+        shipment.length_in = prepared["length_in"]
+        shipment.width_in = prepared["width_in"]
+        shipment.height_in = prepared["height_in"]
+        shipment.shipping_cost = quote.amount
+        shipment.quote_metadata = quote.to_record_metadata()
 
     db.session.commit()
 
@@ -316,8 +894,8 @@ def update_shipment(
         new_value = getattr(shipment, key)
         if old_value != new_value:
             changed_fields[key] = (
-                None if old_value is None else str(old_value),
-                None if new_value is None else str(new_value),
+                _audit_string_value(old_value),
+                _audit_string_value(new_value),
             )
 
     for field_name, (old_value, new_value) in changed_fields.items():
@@ -336,6 +914,7 @@ def update_shipment(
                     {
                         "order_id": shipment.order_id,
                         "shipment_status": shipment.status,
+                        "provider_code": shipment.provider_code,
                     }
                 ),
             )
@@ -351,12 +930,7 @@ def delete_shipment(
     ip_address=None,
     user_agent=None,
 ):
-    """Delete a shipment record.
-
-    Returns
-    -------
-    None
-    """
+    """Delete a shipment record."""
     shipment = get_shipment(shipment_id)
 
     try:
@@ -414,9 +988,116 @@ def get_order_shipping_total(order_id):
         if shipment.status in NON_CANCELLED_STATUSES
     ]
     return sum(
-        (s.shipping_cost or Decimal("0.00") for s in shipments),
+        (shipment.shipping_cost or Decimal("0.00") for shipment in shipments),
         Decimal("0.00"),
     )
+
+
+def _prepare_quote_request(
+    *,
+    weight_lbs=None,
+    length_in=None,
+    width_in=None,
+    height_in=None,
+    shipping_method=None,
+    provider_code=None,
+    destination_postal_code=None,
+    destination_country=None,
+):
+    resolved_provider_code = _resolve_provider_code(provider_code, shipping_method)
+    provider = get_provider(resolved_provider_code)
+    method_code = _clean_text(
+        shipping_method or provider.get_default_method()["code"],
+        "shipping_method",
+    )
+    provider.get_method(method_code)
+
+    requires_weight = provider.requires_weight(method_code)
+    normalized_weight = _validate_decimal(
+        weight_lbs,
+        "weight_lbs",
+        allow_zero=not requires_weight,
+    )
+    if normalized_weight == Decimal("0.00"):
+        normalized_weight = None
+
+    if requires_weight and normalized_weight is None:
+        raise ValueError("Weight is required for the selected shipping provider.")
+
+    normalized_length = _normalize_dimension(length_in, "length_in")
+    normalized_width = _normalize_dimension(width_in, "width_in")
+    normalized_height = _normalize_dimension(height_in, "height_in")
+    normalized_destination_postal_code = _clean_text(
+        destination_postal_code,
+        "destination_postal_code",
+    )
+    normalized_destination_country = _normalize_country(destination_country)
+
+    quote = provider.quote(
+        ShippingQuoteRequest(
+            weight_lbs=normalized_weight,
+            length_in=normalized_length,
+            width_in=normalized_width,
+            height_in=normalized_height,
+            provider_code=resolved_provider_code,
+            method_code=method_code,
+            destination_postal_code=normalized_destination_postal_code,
+            destination_country=normalized_destination_country,
+        )
+    )
+    return {
+        "provider_code": resolved_provider_code,
+        "shipping_method": method_code,
+        "weight_lbs": normalized_weight,
+        "length_in": normalized_length,
+        "width_in": normalized_width,
+        "height_in": normalized_height,
+        "destination_postal_code": normalized_destination_postal_code,
+        "destination_country": normalized_destination_country,
+        "quote": quote,
+    }
+
+
+def _resolve_provider_code(provider_code=None, shipping_method=None):
+    normalized_provider = _normalize_provider_code(provider_code)
+    if normalized_provider:
+        return normalized_provider
+
+    cleaned_method = _clean_text(shipping_method, "shipping_method") if shipping_method else None
+    if cleaned_method:
+        for code, provider_cls in PROVIDER_REGISTRY.items():
+            provider = provider_cls()
+            try:
+                provider.get_method(cleaned_method)
+                return code
+            except ValueError:
+                continue
+
+    return get_default_provider_code()
+
+
+def _normalize_provider_code(provider_code):
+    if provider_code is None:
+        return None
+    cleaned = _clean_text(str(provider_code).lower(), "provider_code")
+    return cleaned.lower() if cleaned else None
+
+
+def _normalize_country(value):
+    cleaned = _clean_text(value or "US", "destination_country")
+    return cleaned.upper() if cleaned else "US"
+
+
+def _get_provider_overrides():
+    raw = config_service.get_config("shipping.provider_overrides")
+    if not raw:
+        return {}
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    return raw if isinstance(raw, dict) else {}
 
 
 def _clean_text(value, field_name):
@@ -458,7 +1139,58 @@ def _validate_decimal(value, field_name, allow_zero=True):
             f"{field_name.replace('_', ' ').title()} must have at most 2 decimal places."
         )
 
-    return decimal_value
+    return decimal_value.quantize(MEASUREMENT_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _normalize_dimension(value, field_name):
+    normalized = _validate_decimal(value, field_name)
+    if normalized in {None, Decimal("0.00")}:
+        return None
+    return normalized
+
+
+def _package_volume(length_in, width_in, height_in):
+    if not all([length_in, width_in, height_in]):
+        return None
+    return Decimal(str(length_in)) * Decimal(str(width_in)) * Decimal(str(height_in))
+
+
+def _decimal_or_zero(value):
+    if value in (None, ""):
+        return Decimal("0.00")
+    return Decimal(str(value))
+
+
+def _quantize_money(value):
+    return Decimal(str(value)).quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _quantize_measure(value):
+    return Decimal(str(value)).quantize(MEASUREMENT_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _format_decimal(value):
+    if value is None:
+        return None
+    return f"{Decimal(str(value)).quantize(MEASUREMENT_QUANTUM, rounding=ROUND_HALF_UP):.2f}"
+
+
+def _json_safe(value):
+    if isinstance(value, Decimal):
+        return _format_decimal(value)
+    if isinstance(value, dict):
+        return {key: _json_safe(val) for key, val in value.items() if val is not None}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _audit_string_value(value):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return json.dumps(_json_safe(value), sort_keys=True)
+    return str(value)
 
 
 def _shipment_audit_data(shipment):
@@ -470,11 +1202,25 @@ def _shipment_audit_data(shipment):
     return json.dumps(
         {
             "order_id": shipment.order_id,
+            "provider_code": shipment.provider_code,
             "shipping_method": shipment.shipping_method,
             "carrier": shipment.carrier,
             "tracking_number": shipment.tracking_number,
             "status": shipment.status,
             "shipping_cost": str(shipment.shipping_cost or "0.00"),
+            "quote_metadata": _json_safe(shipment.quote_metadata or {}),
             "notes": notes,
         }
     )
+
+
+def _format_destination_summary(postal_code, country):
+    postal = postal_code.strip() if isinstance(postal_code, str) and postal_code.strip() else None
+    normalized_country = _normalize_country(country)
+    if postal and normalized_country and normalized_country != "US":
+        return f"{postal}, {normalized_country}"
+    if postal:
+        return postal
+    if normalized_country and normalized_country != "US":
+        return normalized_country
+    return None

--- a/app/templates/orders/shipping.html
+++ b/app/templates/orders/shipping.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from 'macros/forms.html' import render_field, render_submit %}
 
 {% block title %}Shipping - {{ order.order_number }} - Dive Service Management{% endblock %}
 
@@ -13,170 +12,182 @@
         <li class="breadcrumb-item active">Shipping</li>
       </ol>
     </nav>
-    <h1 class="h3 mb-0">Shipping Management</h1>
+    <h1 class="h3 mb-1">Shipping Management</h1>
+    <p class="text-muted mb-0">Capture provider-specific quotes and apply them directly to this order.</p>
   </div>
   <a href="{{ url_for('orders.detail', id=order.id) }}" class="btn btn-outline-secondary">
     <i class="bi bi-arrow-left me-1"></i> Back to Order
   </a>
 </div>
 
-{# ===== SHIPPING SUMMARY ===== #}
-{% if shipments %}
-<div class="card mb-4">
-  <div class="card-header">
-    <h5 class="card-title mb-0"><i class="bi bi-box-seam me-2"></i>Shipping Summary</h5>
-  </div>
-  <div class="card-body">
-    <div class="row">
-      <div class="col-md-4">
-        <p class="mb-1"><strong>Total Shipments:</strong> {{ shipments|length }}</p>
+<div class="row g-4 mb-4">
+  <div class="col-lg-8">
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="card-title mb-0"><i class="bi bi-truck me-2"></i>Add Shipment</h5>
+        <span class="badge text-bg-light border">{{ providers|length }} providers enabled</span>
       </div>
-      <div class="col-md-4">
-        <p class="mb-1"><strong>Total Shipping Cost:</strong>
-          <span class="fw-bold text-success">${{ "%.2f"|format(shipping_total) }}</span>
-        </p>
+      <div class="card-body">
+        <form id="shipment-form" method="POST" action="{{ url_for('orders.create_shipment', id=order.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+          <div class="row g-3">
+            <div class="col-md-4">
+              <label for="provider_code" class="form-label">Provider</label>
+              <select class="form-select" id="provider_code" name="provider_code" data-shipping-input>
+                {% for provider in providers %}
+                <option value="{{ provider.code }}" {{ "selected" if provider.code == default_provider_code else "" }}>
+                  {{ provider.name }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-4">
+              <label for="shipping_method" class="form-label">Service</label>
+              <select class="form-select" id="shipping_method" name="shipping_method" data-shipping-input></select>
+            </div>
+            <div class="col-md-4">
+              <label for="carrier" class="form-label">Display Carrier</label>
+              <input type="text" class="form-control" id="carrier" name="carrier"
+                     placeholder="Defaults to selected provider">
+            </div>
+
+            <div class="col-md-3">
+              <label for="weight_lbs" class="form-label">Weight (lbs)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="weight_lbs"
+                     name="weight_lbs" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="length_in" class="form-label">Length (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="length_in"
+                     name="length_in" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="width_in" class="form-label">Width (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="width_in"
+                     name="width_in" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="height_in" class="form-label">Height (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="height_in"
+                     name="height_in" data-shipping-input>
+            </div>
+
+            <div class="col-md-4">
+              <label for="destination_postal_code" class="form-label">Destination Postal Code</label>
+              <input type="text" class="form-control" id="destination_postal_code" name="destination_postal_code"
+                     value="{{ default_destination_postal_code }}" data-shipping-input>
+            </div>
+            <div class="col-md-4">
+              <label for="destination_country" class="form-label">Destination Country</label>
+              <input type="text" class="form-control" id="destination_country" name="destination_country"
+                     value="{{ default_destination_country }}" data-shipping-input>
+            </div>
+            <div class="col-md-4">
+              <label for="tracking_number" class="form-label">Tracking Number</label>
+              <input type="text" class="form-control" id="tracking_number" name="tracking_number">
+            </div>
+
+            <div class="col-12">
+              <label for="notes" class="form-label">Notes</label>
+              <textarea class="form-control" id="notes" name="notes" rows="2"
+                        placeholder="Optional shipping notes..."></textarea>
+            </div>
+          </div>
+
+          <div class="border rounded-3 p-3 mt-4 bg-body-tertiary">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <div class="fw-semibold">Live Quote</div>
+              <span class="small text-muted" id="shipping-weight-hint">{{ quote_placeholder }}</span>
+            </div>
+            <div id="shipping-quote">
+              {% set quote = None %}
+              {% set placeholder_text = quote_placeholder %}
+              {% include "partials/shipping_quote.html" %}
+            </div>
+          </div>
+
+          <div class="mt-4">
+            <button type="submit" class="btn btn-primary">
+              <i class="bi bi-plus-circle me-1"></i> Create Shipment
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-4">
+    <div class="card h-100">
+      <div class="card-header">
+        <h5 class="card-title mb-0"><i class="bi bi-receipt-cutoff me-2"></i>Shipping Summary</h5>
+      </div>
+      <div class="card-body">
+        <div class="mb-3">
+          <div class="text-muted small text-uppercase">Total Shipments</div>
+          <div class="fs-4 fw-bold">{{ shipments|length }}</div>
+        </div>
+        <div class="mb-3">
+          <div class="text-muted small text-uppercase">Billable Shipping</div>
+          <div class="fs-4 fw-bold text-success">${{ "%.2f"|format(shipping_total) }}</div>
+        </div>
+        <p class="text-muted small mb-0">Invoice previews and generated invoices include non-cancelled shipping totals automatically.</p>
       </div>
     </div>
   </div>
 </div>
-{% endif %}
 
-{# ===== ADD SHIPMENT FORM ===== #}
-<div class="card mb-4">
+<div class="card">
   <div class="card-header">
-    <h5 class="card-title mb-0"><i class="bi bi-plus-circle me-2"></i>Add Shipment</h5>
+    <h5 class="card-title mb-0"><i class="bi bi-box-seam me-2"></i>Shipments ({{ shipments|length }})</h5>
   </div>
   <div class="card-body">
-    <form method="POST" action="{{ url_for('orders.create_shipment', id=order.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-
-      <div class="row g-3 mb-3">
-        <div class="col-md-3">
-          <label for="weight_lbs" class="form-label">Weight (lbs) <span class="text-danger">*</span></label>
-          <input type="number" step="0.01" min="0.01" class="form-control" id="weight_lbs"
-                 name="weight_lbs" required
-                 hx-get="{{ url_for('orders.shipping_estimate', id=order.id) }}"
-                 hx-trigger="keyup changed delay:500ms"
-                 hx-include="[name='length_in'], [name='width_in'], [name='height_in'], [name='shipping_method']"
-                 hx-target="#cost-estimate">
-        </div>
-        <div class="col-md-3">
-          <label for="length_in" class="form-label">Length (in)</label>
-          <input type="number" step="0.01" min="0" class="form-control" id="length_in" name="length_in">
-        </div>
-        <div class="col-md-3">
-          <label for="width_in" class="form-label">Width (in)</label>
-          <input type="number" step="0.01" min="0" class="form-control" id="width_in" name="width_in">
-        </div>
-        <div class="col-md-3">
-          <label for="height_in" class="form-label">Height (in)</label>
-          <input type="number" step="0.01" min="0" class="form-control" id="height_in" name="height_in">
-        </div>
-      </div>
-
-      <div class="row g-3 mb-3">
-        <div class="col-md-3">
-          <label for="shipping_method" class="form-label">Shipping Method</label>
-          <select class="form-select" id="shipping_method" name="shipping_method">
-            {% for m in methods %}
-            <option value="{{ m.code }}">{{ m.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-md-3">
-          <label for="carrier" class="form-label">Carrier</label>
-          <input type="text" class="form-control" id="carrier" name="carrier"
-                 placeholder="e.g. UPS, FedEx, USPS">
-        </div>
-        <div class="col-md-3">
-          <label for="tracking_number" class="form-label">Tracking Number</label>
-          <input type="text" class="form-control" id="tracking_number" name="tracking_number">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Estimated Cost</label>
-          <div id="cost-estimate" class="form-control-plaintext">
-            <span class="text-muted">Enter weight to estimate cost</span>
+    {% if shipments %}
+      {% for shipment in shipments %}
+      {% set quote_data = shipment.quote_metadata or {} %}
+      {% set quote_meta = quote_data.get('metadata', {}) if quote_data is mapping else {} %}
+      <div class="border rounded-3 p-3 mb-3">
+        <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+          <div>
+            <h6 class="mb-1">
+              Shipment #{{ shipment.id }}
+              <span class="badge text-bg-light border ms-2">{{ shipment.status.replace('_', ' ')|title }}</span>
+            </h6>
+            <div class="text-muted small">
+              {{ quote_data.get('provider_name') or shipment.provider_code|default('Provider', true)|replace('_', ' ')|title }}
+              {% if quote_data.get('method_name') or shipment.shipping_method %}
+              · {{ quote_data.get('method_name') or shipment.shipping_method|replace('_', ' ')|title }}
+              {% endif %}
+            </div>
+          </div>
+          <div class="text-end">
+            <div class="fs-5 fw-bold text-success">${{ "%.2f"|format(shipment.shipping_cost or 0) }}</div>
+            <div class="text-muted small">{{ shipment.created_at.strftime('%m/%d/%Y %I:%M %p') if shipment.created_at else 'N/A' }}</div>
           </div>
         </div>
-      </div>
 
-      <div class="row g-3 mb-3">
-        <div class="col-md-12">
-          <label for="notes" class="form-label">Notes</label>
-          <textarea class="form-control" id="notes" name="notes" rows="2"
-                    placeholder="Optional shipping notes..."></textarea>
-        </div>
-      </div>
-
-      <button type="submit" class="btn btn-primary">
-        <i class="bi bi-plus-circle me-1"></i> Create Shipment
-      </button>
-    </form>
-  </div>
-</div>
-
-{# ===== EXISTING SHIPMENTS ===== #}
-{% if shipments %}
-<div class="card mb-4">
-  <div class="card-header">
-    <h5 class="card-title mb-0"><i class="bi bi-truck me-2"></i>Shipments ({{ shipments|length }})</h5>
-  </div>
-  <div class="card-body">
-    {% for shipment in shipments %}
-    <div class="border rounded p-3 mb-3">
-      <div class="d-flex justify-content-between align-items-start mb-2">
-        <div>
-          <h6 class="mb-1">
-            Shipment #{{ shipment.id }}
-            {% if shipment.status == 'pending' %}
-            <span class="badge bg-secondary ms-2">Pending</span>
-            {% elif shipment.status == 'shipped' %}
-            <span class="badge bg-info ms-2">Shipped</span>
-            {% elif shipment.status == 'in_transit' %}
-            <span class="badge bg-primary ms-2">In Transit</span>
-            {% elif shipment.status == 'delivered' %}
-            <span class="badge bg-success ms-2">Delivered</span>
-            {% elif shipment.status == 'cancelled' %}
-            <span class="badge bg-danger ms-2">Cancelled</span>
+        <div class="row small g-2 mb-3">
+          <div class="col-md-3"><strong>Weight:</strong> {{ shipment.weight_lbs or "N/A" }} lbs</div>
+          <div class="col-md-3">
+            <strong>Dimensions:</strong>
+            {% if shipment.length_in and shipment.width_in and shipment.height_in %}
+              {{ shipment.length_in }}" x {{ shipment.width_in }}" x {{ shipment.height_in }}"
+            {% else %}
+              N/A
             {% endif %}
-          </h6>
-          <p class="text-muted small mb-0">
-            Created {{ shipment.created_at.strftime('%m/%d/%Y %I:%M %p') if shipment.created_at else 'N/A' }}
-          </p>
+          </div>
+          <div class="col-md-3"><strong>Carrier:</strong> {{ shipment.carrier or quote_data.get('provider_name') or "N/A" }}</div>
+          <div class="col-md-3"><strong>Tracking:</strong> {{ shipment.tracking_number or "Not assigned" }}</div>
+          <div class="col-md-3"><strong>Destination:</strong> {{ quote_meta.get('destination_summary') or "N/A" }}</div>
+          <div class="col-md-3"><strong>ETA:</strong> {{ quote_meta.get('estimated_delivery_days') or "N/A" }}</div>
+          <div class="col-md-3"><strong>Provider Code:</strong> {{ shipment.provider_code or "N/A" }}</div>
+          <div class="col-md-3"><strong>Method Code:</strong> {{ shipment.shipping_method or "N/A" }}</div>
         </div>
-        <div class="text-end">
-          <span class="h5 text-success">${{ "%.2f"|format(shipment.shipping_cost or 0) }}</span>
-        </div>
-      </div>
 
-      <div class="row small mb-2">
-        <div class="col-md-3">
-          <strong>Weight:</strong> {{ shipment.weight_lbs }} lbs
-        </div>
-        {% if shipment.length_in and shipment.width_in and shipment.height_in %}
-        <div class="col-md-3">
-          <strong>Dimensions:</strong>
-          {{ shipment.length_in }}" x {{ shipment.width_in }}" x {{ shipment.height_in }}"
-        </div>
+        {% if shipment.notes %}
+        <p class="small mb-3"><strong>Notes:</strong> {{ shipment.notes }}</p>
         {% endif %}
-        {% if shipment.carrier %}
-        <div class="col-md-3">
-          <strong>Carrier:</strong> {{ shipment.carrier }}
-        </div>
-        {% endif %}
-        {% if shipment.tracking_number %}
-        <div class="col-md-3">
-          <strong>Tracking:</strong> {{ shipment.tracking_number }}
-        </div>
-        {% endif %}
-      </div>
 
-      {% if shipment.notes %}
-      <p class="small mb-2"><strong>Notes:</strong> {{ shipment.notes }}</p>
-      {% endif %}
-
-      {# Update form #}
-      <div class="border-top pt-2 mt-2">
         <form method="POST" action="{{ url_for('orders.update_shipment', id=order.id, shipment_id=shipment.id) }}" class="row g-2 align-items-end">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="col-md-3">
@@ -219,14 +230,95 @@
           </div>
         </form>
       </div>
+      {% endfor %}
+    {% else %}
+    <div class="text-center text-muted py-4">
+      <i class="bi bi-box-seam" style="font-size: 2rem;"></i>
+      <p class="mt-2 mb-0">No shipments configured for this order yet.</p>
     </div>
-    {% endfor %}
+    {% endif %}
   </div>
 </div>
-{% else %}
-<div class="text-center text-muted py-4">
-  <i class="bi bi-box-seam" style="font-size: 2rem;"></i>
-  <p class="mt-2">No shipments configured for this order yet.</p>
-</div>
-{% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+(() => {
+  const providers = {{ providers|tojson }};
+  const providerMap = Object.fromEntries(providers.map((provider) => [provider.code, provider]));
+  const form = document.getElementById("shipment-form");
+  if (!form) return;
+
+  const estimateUrl = {{ url_for('orders.shipping_estimate', id=order.id)|tojson }};
+  const providerInput = form.querySelector("[name='provider_code']");
+  const methodInput = form.querySelector("[name='shipping_method']");
+  const carrierInput = form.querySelector("[name='carrier']");
+  const quoteTarget = document.getElementById("shipping-quote");
+  const weightHint = document.getElementById("shipping-weight-hint");
+
+  function getSelectedProvider() {
+    return providerMap[providerInput.value] || providers[0];
+  }
+
+  function syncMethods() {
+    const provider = getSelectedProvider();
+    const methods = provider.methods || [];
+    const current = methodInput.value;
+    methodInput.innerHTML = "";
+    methods.forEach((method) => {
+      const option = document.createElement("option");
+      option.value = method.code;
+      option.textContent = method.name;
+      methodInput.appendChild(option);
+    });
+    methodInput.value = methods.some((method) => method.code === current)
+      ? current
+      : (provider.default_method_code || (methods[0] && methods[0].code) || "");
+
+    if (!carrierInput.value.trim()) {
+      carrierInput.value = provider.name || "";
+    }
+    weightHint.textContent = provider.requires_weight
+      ? "Weight is required for this provider."
+      : "Local pickup can be created without package weight.";
+  }
+
+  async function refreshQuote() {
+    const params = new URLSearchParams();
+    ["provider_code", "shipping_method", "weight_lbs", "length_in", "width_in", "height_in", "destination_postal_code", "destination_country"]
+      .forEach((field) => {
+        const input = form.querySelector(`[name='${field}']`);
+        if (input && input.value.trim()) {
+          params.set(field, input.value.trim());
+        }
+      });
+
+    const response = await fetch(`${estimateUrl}?${params.toString()}`, {
+      headers: { "X-Requested-With": "XMLHttpRequest" }
+    });
+    quoteTarget.innerHTML = await response.text();
+  }
+
+  form.querySelectorAll("[data-shipping-input]").forEach((input) => {
+    const eventName = input.tagName === "SELECT" ? "change" : "input";
+    input.addEventListener(eventName, () => {
+      if (input === providerInput) {
+        syncMethods();
+      }
+      refreshQuote();
+    });
+    if (eventName !== "change") {
+      input.addEventListener("change", () => {
+        if (input === providerInput) {
+          syncMethods();
+        }
+        refreshQuote();
+      });
+    }
+  });
+
+  syncMethods();
+  refreshQuote();
+})();
+</script>
 {% endblock %}

--- a/app/templates/partials/shipping_quote.html
+++ b/app/templates/partials/shipping_quote.html
@@ -1,0 +1,47 @@
+{% if quote %}
+<div class="border rounded-3 p-3 bg-body-tertiary">
+  <div class="d-flex justify-content-between align-items-start gap-3">
+    <div>
+      <div class="text-muted text-uppercase small fw-semibold">Estimated Quote</div>
+      <div class="fs-4 fw-bold text-success mb-1">{{ quote.amount_display }}</div>
+      <div class="fw-semibold">{{ quote.provider_name }} · {{ quote.method_name }}</div>
+    </div>
+    {% if quote.metadata.quote_source %}
+    <span class="badge text-bg-light border">
+      {{ quote.metadata.quote_source|replace('_', ' ')|title }}
+    </span>
+    {% endif %}
+  </div>
+
+  <div class="small text-muted mt-2">
+    {% if quote.metadata.destination_summary %}
+    <div>Destination: {{ quote.metadata.destination_summary }}</div>
+    {% endif %}
+    {% if quote.metadata.estimated_delivery_days %}
+    <div>ETA: {{ quote.metadata.estimated_delivery_days }}</div>
+    {% endif %}
+    {% if quote.metadata.billable_weight_lbs %}
+    <div>
+      Billable weight: {{ quote.metadata.billable_weight_lbs }} lbs
+      {% if quote.metadata.dimensional_weight_lbs %}
+      <span>(dimensional {{ quote.metadata.dimensional_weight_lbs }} lbs)</span>
+      {% endif %}
+    </div>
+    {% endif %}
+    {% if quote.metadata.tier_label %}
+    <div>Rate tier: {{ quote.metadata.tier_label }}</div>
+    {% endif %}
+    {% if quote.metadata.pickup_message %}
+    <div>{{ quote.metadata.pickup_message }}</div>
+    {% endif %}
+    {% if quote.metadata.destination_surcharge %}
+    <div>Destination surcharge: ${{ quote.metadata.destination_surcharge }}</div>
+    {% endif %}
+    {% if quote.metadata.oversize_applied %}
+    <div>Oversize surcharge applied.</div>
+    {% endif %}
+  </div>
+</div>
+{% else %}
+<span class="text-muted">{{ placeholder_text }}</span>
+{% endif %}

--- a/app/templates/tools/hub.html
+++ b/app/templates/tools/hub.html
@@ -74,6 +74,26 @@
     </div>
   </div>
 
+  {# Shipping Calculator #}
+  <div class="col-md-6 col-lg-4">
+    <div class="card h-100 shadow-sm">
+      <div class="card-body d-flex flex-column">
+        <div class="d-flex align-items-center mb-3">
+          <div class="rounded-circle bg-info bg-opacity-10 p-3 me-3">
+            <i class="bi bi-truck fs-4 text-info"></i>
+          </div>
+          <h5 class="card-title mb-0">Shipping Calculator</h5>
+        </div>
+        <p class="card-text text-muted flex-grow-1">
+          Compare USPS, UPS, FedEx, DHL, local pickup, and flat-rate quotes using package and destination data.
+        </p>
+        <a href="{{ url_for('tools.shipping_calculator') }}" class="btn btn-outline-info mt-2">
+          <i class="bi bi-globe-americas me-1"></i> Open Calculator
+        </a>
+      </div>
+    </div>
+  </div>
+
   {# Leak Test Log #}
   <div class="col-md-6 col-lg-4">
     <div class="card h-100 shadow-sm">

--- a/app/templates/tools/shipping_calculator.html
+++ b/app/templates/tools/shipping_calculator.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+
+{% block title %}Shipping Calculator - Dive Service Management{% endblock %}
+
+{% block content %}
+<div class="mb-4">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb mb-1">
+      <li class="breadcrumb-item"><a href="{{ url_for('tools.hub') }}">Tools</a></li>
+      <li class="breadcrumb-item active">Shipping Calculator</li>
+    </ol>
+  </nav>
+  <h1 class="h3 mb-1">Shipping Calculator</h1>
+  <p class="text-muted mb-0">Compare configured providers with package dimensions and destination details.</p>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-7">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0"><i class="bi bi-globe-americas me-2"></i>Quote Inputs</h5>
+      </div>
+      <div class="card-body">
+        <form id="shipping-calculator-form">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label for="calc_provider_code" class="form-label">Provider</label>
+              <select class="form-select" id="calc_provider_code" name="provider_code" data-shipping-input>
+                {% for provider in providers %}
+                <option value="{{ provider.code }}" {{ "selected" if provider.code == default_provider_code else "" }}>
+                  {{ provider.name }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label for="calc_shipping_method" class="form-label">Service</label>
+              <select class="form-select" id="calc_shipping_method" name="shipping_method" data-shipping-input></select>
+            </div>
+            <div class="col-md-3">
+              <label for="calc_weight_lbs" class="form-label">Weight (lbs)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="calc_weight_lbs" name="weight_lbs" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="calc_length_in" class="form-label">Length (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="calc_length_in" name="length_in" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="calc_width_in" class="form-label">Width (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="calc_width_in" name="width_in" data-shipping-input>
+            </div>
+            <div class="col-md-3">
+              <label for="calc_height_in" class="form-label">Height (in)</label>
+              <input type="number" step="0.01" min="0" class="form-control" id="calc_height_in" name="height_in" data-shipping-input>
+            </div>
+            <div class="col-md-6">
+              <label for="calc_destination_postal_code" class="form-label">Destination Postal Code</label>
+              <input type="text" class="form-control" id="calc_destination_postal_code" name="destination_postal_code" data-shipping-input>
+            </div>
+            <div class="col-md-6">
+              <label for="calc_destination_country" class="form-label">Destination Country</label>
+              <input type="text" class="form-control" id="calc_destination_country" name="destination_country"
+                     value="{{ default_destination_country }}" data-shipping-input>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-5">
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="card-title mb-0"><i class="bi bi-currency-dollar me-2"></i>Estimated Quote</h5>
+        <span class="small text-muted" id="calculator-weight-hint">{{ quote_placeholder }}</span>
+      </div>
+      <div class="card-body">
+        <div id="shipping-calculator-quote">
+          <span class="text-muted">{{ quote_placeholder }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(() => {
+  const providers = {{ providers|tojson }};
+  const providerMap = Object.fromEntries(providers.map((provider) => [provider.code, provider]));
+  const form = document.getElementById("shipping-calculator-form");
+  if (!form) return;
+
+  const estimateUrl = {{ url_for('tools.shipping_calculator_estimate')|tojson }};
+  const providerInput = form.querySelector("[name='provider_code']");
+  const methodInput = form.querySelector("[name='shipping_method']");
+  const quoteTarget = document.getElementById("shipping-calculator-quote");
+  const weightHint = document.getElementById("calculator-weight-hint");
+
+  function getSelectedProvider() {
+    return providerMap[providerInput.value] || providers[0];
+  }
+
+  function syncMethods() {
+    const provider = getSelectedProvider();
+    const methods = provider.methods || [];
+    const current = methodInput.value;
+    methodInput.innerHTML = "";
+    methods.forEach((method) => {
+      const option = document.createElement("option");
+      option.value = method.code;
+      option.textContent = method.name;
+      methodInput.appendChild(option);
+    });
+    methodInput.value = methods.some((method) => method.code === current)
+      ? current
+      : (provider.default_method_code || (methods[0] && methods[0].code) || "");
+    weightHint.textContent = provider.requires_weight
+      ? "Weight is required for this provider."
+      : "Local pickup quotes immediately at $0.00.";
+  }
+
+  async function refreshQuote() {
+    const params = new URLSearchParams();
+    ["provider_code", "shipping_method", "weight_lbs", "length_in", "width_in", "height_in", "destination_postal_code", "destination_country"]
+      .forEach((field) => {
+        const input = form.querySelector(`[name='${field}']`);
+        if (input && input.value.trim()) {
+          params.set(field, input.value.trim());
+        }
+      });
+
+    const response = await fetch(`${estimateUrl}?${params.toString()}`, {
+      headers: { "X-Requested-With": "XMLHttpRequest" }
+    });
+    quoteTarget.innerHTML = await response.text();
+  }
+
+  form.querySelectorAll("[data-shipping-input]").forEach((input) => {
+    const eventName = input.tagName === "SELECT" ? "change" : "input";
+    input.addEventListener(eventName, () => {
+      if (input === providerInput) {
+        syncMethods();
+      }
+      refreshQuote();
+    });
+    if (eventName !== "change") {
+      input.addEventListener("change", () => {
+        if (input === providerInput) {
+          syncMethods();
+        }
+        refreshQuote();
+      });
+    }
+  });
+
+  syncMethods();
+  refreshQuote();
+})();
+</script>
+{% endblock %}

--- a/migrations/versions/r5b6c7d8e9f0_shipping_provider_metadata.py
+++ b/migrations/versions/r5b6c7d8e9f0_shipping_provider_metadata.py
@@ -1,0 +1,26 @@
+"""Add provider metadata columns to shipments.
+
+Revision ID: r5b6c7d8e9f0
+Revises: q4a5b6c7d8e9
+Create Date: 2026-03-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "r5b6c7d8e9f0"
+down_revision = "q4a5b6c7d8e9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("shipments", sa.Column("provider_code", sa.String(length=50), nullable=True))
+    op.add_column("shipments", sa.Column("quote_metadata", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("shipments", "quote_metadata")
+    op.drop_column("shipments", "provider_code")

--- a/tests/blueprint/test_tools_routes.py
+++ b/tests/blueprint/test_tools_routes.py
@@ -53,6 +53,11 @@ class TestUnauthenticated:
         assert response.status_code == 302
         assert "/login" in response.location
 
+    def test_shipping_calculator_unauthenticated_redirects(self, client):
+        response = client.get("/tools/shipping-calculator")
+        assert response.status_code == 302
+        assert "/login" in response.location
+
 
 # ---------------------------------------------------------------------------
 # Authenticated access
@@ -89,3 +94,24 @@ class TestAuthenticatedAccess:
     def test_converter(self, logged_in_client, app, db_session):
         response = logged_in_client.get("/tools/converter")
         assert response.status_code == 200
+
+    def test_shipping_calculator(self, logged_in_client, app, db_session):
+        response = logged_in_client.get("/tools/shipping-calculator")
+        assert response.status_code == 200
+        assert b"Shipping Calculator" in response.data
+        assert b"Local pickup stays at $0.00" in response.data
+
+    def test_shipping_calculator_estimate(self, logged_in_client, app, db_session):
+        response = logged_in_client.get(
+            "/tools/shipping-calculator/estimate?provider_code=fedex&shipping_method=fedex_ground&weight_lbs=8&destination_postal_code=90210&destination_country=US"
+        )
+        assert response.status_code == 200
+        assert b"FedEx" in response.data
+        assert b"90210" in response.data
+
+    def test_shipping_calculator_invalid_provider_shows_error(self, logged_in_client, app, db_session):
+        response = logged_in_client.get(
+            f"/tools/shipping-calculator/estimate?provider_code={'x' * 51}"
+        )
+        assert response.status_code == 200
+        assert b"Provider Code must be 50 characters or fewer." in response.data

--- a/tests/test_services/test_shipping.py
+++ b/tests/test_services/test_shipping.py
@@ -59,6 +59,66 @@ class TestFlatRateProvider:
         assert methods[0]["code"] == "flat_rate"
         assert methods[0]["name"] == "Flat Rate Shipping"
 
+    def test_quote_shipping_tracks_destination_metadata(self, app, db_session):
+        """Destination details should flow through provider quotes."""
+        quote = shipping_service.quote_shipping(
+            weight_lbs=Decimal("5.00"),
+            provider_code="ups",
+            method="ups_ground",
+            destination_postal_code="V6B1A1",
+            destination_country="CA",
+        )
+
+        assert quote.provider_code == "ups"
+        assert quote.metadata["destination_postal_code"] == "V6B1A1"
+        assert quote.metadata["destination_country"] == "CA"
+        assert quote.metadata["international"] is True
+        assert quote.amount > Decimal("0.00")
+
+    def test_local_pickup_quote_requires_no_weight(self, app, db_session):
+        """Local pickup should quote successfully with no package measurements."""
+        quote = shipping_service.quote_shipping(
+            provider_code="local_pickup",
+            method="local_pickup",
+        )
+
+        assert quote.amount == Decimal("0.00")
+        assert quote.method_code == "local_pickup"
+
+    def test_local_pickup_is_workflow_default_provider(self, monkeypatch, app, db_session):
+        """UI workflows should default to local pickup when available."""
+        monkeypatch.setattr(
+            shipping_service.config_service,
+            "get_config",
+            lambda key, default=None: default,
+        )
+
+        assert shipping_service.get_workflow_default_provider_code() == "local_pickup"
+
+    def test_required_providers_always_enabled(self, monkeypatch, app, db_session):
+        """Local pickup and flat rate should remain available even if config omits them."""
+        monkeypatch.setattr(
+            shipping_service.config_service,
+            "get_config",
+            lambda key, default=None: ["ups"] if key == "shipping.enabled_providers" else default,
+        )
+
+        enabled_codes = shipping_service.get_enabled_provider_codes()
+        assert enabled_codes[0] == "local_pickup"
+        assert "ups" in enabled_codes
+        assert "flat_rate" in enabled_codes
+
+    def test_disabled_provider_is_rejected(self, monkeypatch, app, db_session):
+        """Disabled providers should not be usable via direct requests."""
+        monkeypatch.setattr(
+            shipping_service.config_service,
+            "get_config",
+            lambda key, default=None: ["ups"] if key == "shipping.enabled_providers" else default,
+        )
+
+        with pytest.raises(ValueError, match="disabled"):
+            shipping_service.get_provider("fedex")
+
 
 # ======================================================================
 # Service CRUD tests
@@ -90,6 +150,26 @@ class TestShipmentCRUD:
         assert shipment.weight_lbs == Decimal("10.00")
         assert shipment.shipping_cost == Decimal("14.99")
         assert shipment.status == "pending"
+
+    def test_create_shipment_persists_provider_quote_metadata(self, app, db_session):
+        """Shipments should persist provider and destination quote metadata."""
+        self._set_sessions(db_session)
+        order = ServiceOrderFactory()
+        db_session.flush()
+
+        shipment = shipping_service.create_shipment(
+            order_id=order.id,
+            weight_lbs=Decimal("8.00"),
+            provider_code="fedex",
+            shipping_method="fedex_two_day",
+            destination_postal_code="33139",
+            destination_country="US",
+        )
+
+        assert shipment.provider_code == "fedex"
+        assert shipment.quote_metadata["provider_name"] == "FedEx"
+        assert shipment.quote_metadata["metadata"]["destination_postal_code"] == "33139"
+        assert shipment.carrier == "FedEx"
 
     def test_update_shipment_tracking(self, app, db_session):
         """Updating tracking number should persist."""
@@ -349,15 +429,17 @@ class TestShippingRoutes:
         response = logged_in_client.get(f"/orders/{order.id}/shipping")
         assert response.status_code == 200
         assert b"Shipping Management" in response.data
+        assert b"Local pickup stays at $0.00" in response.data
 
     def test_estimate_endpoint(self, app, db_session, logged_in_client):
         """HTMX estimate endpoint should return cost fragment."""
         order = self._create_order(db_session)
         response = logged_in_client.get(
-            f"/orders/{order.id}/shipping/estimate?weight_lbs=10"
+            f"/orders/{order.id}/shipping/estimate?provider_code=ups&shipping_method=ups_ground&weight_lbs=10&destination_postal_code=77002&destination_country=US"
         )
         assert response.status_code == 200
-        assert b"$14.99" in response.data
+        assert b"UPS" in response.data
+        assert b"77002" in response.data
         assert b"text-success" in response.data
 
     def test_estimate_endpoint_rejects_nan(self, app, db_session, logged_in_client):
@@ -367,7 +449,17 @@ class TestShippingRoutes:
             f"/orders/{order.id}/shipping/estimate?weight_lbs=NaN"
         )
         assert response.status_code == 200
-        assert b"Enter weight to estimate cost" in response.data
+        assert b"Enter weight and optional dimensions to estimate shipping" in response.data
+
+    def test_estimate_endpoint_invalid_provider_shows_error(self, app, db_session, logged_in_client):
+        """Malformed provider inputs should render an error fragment instead of 500ing."""
+        order = self._create_order(db_session)
+        response = logged_in_client.get(
+            f"/orders/{order.id}/shipping/estimate?provider_code={'x' * 51}"
+        )
+
+        assert response.status_code == 200
+        assert b"Provider Code must be 50 characters or fewer." in response.data
 
     def test_create_shipment_via_form(self, app, db_session, logged_in_client):
         """POST should create a shipment and redirect."""
@@ -376,7 +468,10 @@ class TestShippingRoutes:
             f"/orders/{order.id}/shipping",
             data={
                 "weight_lbs": "10.00",
-                "carrier": "USPS",
+                "provider_code": "usps",
+                "shipping_method": "usps_priority_mail",
+                "destination_postal_code": "30301",
+                "destination_country": "US",
                 "tracking_number": "TEST123",
             },
             follow_redirects=True,
@@ -386,7 +481,27 @@ class TestShippingRoutes:
 
         shipments = shipping_service.get_order_shipments(order.id)
         assert len(shipments) == 1
+        assert shipments[0].provider_code == "usps"
         assert shipments[0].carrier == "USPS"
+
+    def test_create_local_pickup_without_weight(self, app, db_session, logged_in_client):
+        """Local pickup shipments should be creatable without weight."""
+        order = self._create_order(db_session)
+        response = logged_in_client.post(
+            f"/orders/{order.id}/shipping",
+            data={
+                "provider_code": "local_pickup",
+                "shipping_method": "local_pickup",
+                "destination_country": "US",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert b"Shipment created successfully" in response.data
+        shipments = shipping_service.get_order_shipments(order.id)
+        assert shipments[0].provider_code == "local_pickup"
+        assert shipments[0].shipping_cost == Decimal("0.00")
 
     def test_order_detail_financial_summary_includes_shipping(
         self, app, db_session, logged_in_client

--- a/tests/uat/test_uat_tools.py
+++ b/tests/uat/test_uat_tools.py
@@ -27,6 +27,12 @@ class TestToolsUAT:
         admin_page.goto(f"{base_url}/tools/pricing-calculator")
         expect(admin_page.locator("h1")).to_contain_text("Pricing")
 
+    def test_shipping_calculator(self, admin_page: Page, base_url: str):
+        """Shipping calculator page loads."""
+        admin_page.goto(f"{base_url}/tools/shipping-calculator")
+        expect(admin_page.locator("h1")).to_contain_text("Shipping Calculator")
+        expect(admin_page.locator("text=Provider")).to_be_visible()
+
     def test_unit_converter(self, admin_page: Page, base_url: str):
         """Unit converter page loads."""
         admin_page.goto(f"{base_url}/tools/converter")


### PR DESCRIPTION
## Summary
- expand shipping into a provider registry with USPS, UPS, FedEx, DHL, local pickup, and flat-rate fallback
- add destination-aware quote flows to order shipping and a new standalone tools calculator
- persist shipment provider metadata, add migration coverage, and enforce enabled-provider restrictions

## Verification
- docker compose -f docker-compose.test-dev.yml exec -T test pytest tests/test_services/test_shipping.py tests/blueprint/test_tools_routes.py -q --tb=short

Closes #46