### PR TITLE
Sync planning docs after shipping backlog closure

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -512,11 +512,18 @@
 - Verified the portal equipment/invite slice in the persistent Docker test container with `tests/unit/services/test_portal_service.py` + `tests/blueprint/test_portal_equipment.py` + `tests/blueprint/test_customer_portal_invites.py` + `tests/blueprint/test_portal_auth.py` + `tests/blueprint/test_portal.py` + `tests/blueprint/test_portal_invoices.py` + `tests/test_utils/test_pdf.py`
 
 **2026-03-25 Wave 5 Kickoff**
-- Pulled remote GitHub backlog before the final wave: open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) is the only open issue and remains a follow-on expansion of the shipping framework unless reprioritized into a later sprint
+- Pulled remote GitHub backlog before the final wave: issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) was the only open issue and was promoted into the active pre-Wave-5 closure lane
 - Confirmed all Wave 4 feature lanes were shipped via remote PRs: [#48](https://github.com/llathrop/Dive_Service_Management/pull/48), [#50](https://github.com/llathrop/Dive_Service_Management/pull/50), [#52](https://github.com/llathrop/Dive_Service_Management/pull/52), and [#51](https://github.com/llathrop/Dive_Service_Management/pull/51)
-- Confirmed the only remaining open PR on GitHub is unrelated portal/gallery work [#45](https://github.com/llathrop/Dive_Service_Management/pull/45)
+- Confirmed the only remaining open PR on GitHub at kickoff was unrelated portal/gallery work [#45](https://github.com/llathrop/Dive_Service_Management/pull/45); it was closed as stale before final-wave execution resumed
 - Started final-wave planning/doc reconciliation on a dedicated docs branch so `PROGRESS.md`, `README.plan`, and shared memory all reflect the post-Wave-4 state
 - Merged follow-up [PR #56](https://github.com/llathrop/Dive_Service_Management/pull/56) after QA flagged that the new equipment portal surface was not discoverable from the shared nav or order detail view
+
+**2026-03-25 Shipping Backlog Closure**
+- Completed the follow-on shipping carrier expansion from remote issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) in a dedicated worktree/branch, reviewed it with QA and security agents, and merged it via [PR #59](https://github.com/llathrop/Dive_Service_Management/pull/59)
+- Expanded the shipping framework to support provider registry selection (USPS, UPS, FedEx, DHL, Local Pickup, Flat Rate), destination-aware quotes, enabled-provider enforcement, and a standalone tools calculator
+- Verified the shipping expansion in the persistent Docker test container with `tests/test_services/test_shipping.py` + `tests/blueprint/test_tools_routes.py`
+- Synced `master` to `origin/master` after the merge; remote GitHub backlog is now clear with zero open issues and zero open PRs
+- Cleaned merged feature branches and stale worktree directories so Wave 5 can start from a single clean `master` worktree
 
 **Wave 5: Final Polish** (3 agents)
 - [ ] 5A: Capture missing screenshots

--- a/README.plan
+++ b/README.plan
@@ -159,9 +159,9 @@ The current source of truth for sprint execution status is `PROGRESS.md`.
 As of 2026-03-25:
 
 - Waves 1-4 of Sprint `2026-03-22B` are complete and pushed on `master`
+- The remote shipping follow-on was completed and merged via [PR #59](https://github.com/llathrop/Dive_Service_Management/pull/59)
 - The current execution stage is **Wave 5: Final Polish**
-- Open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) remains the only remote backlog item and is currently planned as a follow-on shipping expansion after the final wave unless reprioritized
-- Open PR [#45](https://github.com/llathrop/Dive_Service_Management/pull/45) is still active on GitHub but is unrelated to the Wave 4 portal rollout
+- There is no remaining open remote backlog right now: issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) is closed and stale PR [#45](https://github.com/llathrop/Dive_Service_Management/pull/45) was closed without merge
 - Every new feature, fix, or docs lane now requires an isolated worktree, a remote feature branch, and a GitHub PR before merge to `master`
 - Recent Wave 3 recovery / Wave 4 kickoff direct pushes on `master` are a historical exception and are not cleanly backfillable into real review PRs without rewriting published history
 
@@ -177,3 +177,4 @@ As of 2026-03-25:
 - Capture missing screenshots
 - Finalize sprint documentation
 - Run integration smoke tests
+- Execute each Wave 5 lane from its own worktree/branch/PR with QA/security review before merge

--- a/docs/review/consolidated_todos.md
+++ b/docs/review/consolidated_todos.md
@@ -3,7 +3,7 @@
 Prioritized findings from 4 parallel audits: code, documentation, test suite, and security.
 Use this as input for planning the next sprint.
 
-Remote backlog intake note: GitHub open issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) adds a follow-on shipping-provider expansion (real-time carrier integrations) that is not part of the original four audits. It should be planned separately from the remaining audit items below.
+Remote backlog intake note: GitHub issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) was the shipping-provider follow-on lane; it has now been completed and merged via [PR #59](https://github.com/llathrop/Dive_Service_Management/pull/59).
 
 ---
 
@@ -94,7 +94,7 @@ Remote backlog intake note: GitHub open issue [#46](https://github.com/llathrop/
 
 ## Feature Proposals (Discussion — Not Prioritized)
 
-Status note: items 1, 3, 4, 5, 6, 7, 8, 9, and 10 below have already been implemented across Sprint `2026-03-22B` Waves 1-4. The primary remaining proposal in this section is the real-time carrier shipping expansion (`11`), which is tracked separately as remote issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46).
+Status note: items 1, 3, 4, 5, 6, 7, 8, 9, 10, and 11 below have already been implemented across Sprint `2026-03-22B` Waves 1-4 plus the post-Wave-4 shipping follow-on.
 
 1. **Wire notification triggers** — 3-6 lines of glue to call existing notify functions from inventory/order/invoice services. Immediate value.
 2. **Part linking UI** — Modal on price list detail to associate inventory parts. Enables auto-deduction.
@@ -106,7 +106,7 @@ Status note: items 1, 3, 4, 5, 6, 7, 8, 9, and 10 below have already been implem
 8. **Auto-populate last_service_date** — Set when order transitions to "completed".
 9. **Audit log export** — CSV/XLSX export for compliance.
 10. **Password recovery via email** — Enable Flask-Security's recovery flow (email now works).
-11. **Real-time carrier shipping framework** — Tracked separately as GitHub issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46); extends the current flat-rate/pluggable shipping base with carrier APIs.
+11. **Real-time carrier shipping framework** — Completed via [PR #59](https://github.com/llathrop/Dive_Service_Management/pull/59); extends the current flat-rate/pluggable shipping base with a multi-provider registry, standalone calculator, destination-aware quotes, and shipment metadata.
 
 ---
 


### PR DESCRIPTION
## Summary
- record PR #59 / issue #46 closure in the sprint log and planning docs
- remove stale references to open remote backlog in README.plan and consolidated todos
- document final polish as the active execution stage at that point

## Notes
- shared MEMORY.md was also updated locally as agent memory, but it is not part of this tracked docs branch