### PR TITLE
Close sprint 2026-03-22B and harden final gate

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -427,9 +427,9 @@
 **GitHub Issues**: #44 — closed
 **Tests**: 1458 total, all passing
 
-### Sprint 2026-03-22B (Wave 1-4 Complete, Wave 5 In Progress)
+### Sprint 2026-03-22B (Complete)
 
-**Scope**: All 48 audit fix items (P1: 11, P2: 20, P3: 17) + all 13 feature proposals from consolidated TODO list. Waves 1-4 are landed and pushed on `master`; Wave 5 is now the active execution stage.
+**Scope**: All 48 audit fix items (P1: 11, P2: 20, P3: 17) + all 13 feature proposals from consolidated TODO list. Waves 1-5 are landed and pushed on `master`.
 
 **Wave 1: P1 Fixes + Quick-Win Features** (Complete)
 - [x] Security headers, secure session cookies, and rate limiting added
@@ -527,8 +527,15 @@
 
 **Wave 5: Final Polish** (3 agents)
 - [x] 5A: Capture missing screenshots
-- [ ] 5B: Sprint documentation finalization
+- [x] 5B: Sprint documentation finalization
 - [x] 5C: Integration smoke tests
+
+**2026-03-25 Wave 5 Completion**
+- Merged Wave 5A via [PR #62](https://github.com/llathrop/Dive_Service_Management/pull/62), adding the reproducible docs screenshot capture lane plus tracked `customer_detail.png` and `item_detail_service_history.png` assets
+- Merged Wave 5C via [PR #63](https://github.com/llathrop/Dive_Service_Management/pull/63), adding the Dockerized final smoke gate and authenticated core-route smoke coverage
+- Merged Wave 5B via [PR #64](https://github.com/llathrop/Dive_Service_Management/pull/64), reconciling architecture, configuration, installation, user-guide, and review-tracker docs with the shipped application
+- Final post-merge gate passed on `master` via `./scripts/final_wave_gate.sh`
+- Sprint `2026-03-22B` is complete; the repo is ready for the next planning cycle from a clean, fully merged `master`
 
 **5C completion note**
 - Added an authenticated smoke route lane for the core internal surfaces and a single Dockerized handoff gate via `make test-gate`

--- a/README.plan
+++ b/README.plan
@@ -161,7 +161,7 @@ As of 2026-03-25:
 
 - Waves 1-4 of Sprint `2026-03-22B` are complete and pushed on `master`
 - The remote shipping follow-on was completed and merged via [PR #59](https://github.com/llathrop/Dive_Service_Management/pull/59)
-- The current execution stage is **Wave 5: Final Polish**
+- Sprint `2026-03-22B` is complete on `master`
 - There is no remaining open remote backlog right now: issue [#46](https://github.com/llathrop/Dive_Service_Management/issues/46) is closed and stale PR [#45](https://github.com/llathrop/Dive_Service_Management/pull/45) was closed without merge
 - Every new feature, fix, or docs lane now requires an isolated worktree, a remote feature branch, and a GitHub PR before merge to `master`
 - Recent Wave 3 recovery / Wave 4 kickoff direct pushes on `master` are a historical exception and are not cleanly backfillable into real review PRs without rewriting published history
@@ -173,9 +173,9 @@ As of 2026-03-25:
 - **4C: Portal invoice view + payment provider framework**: Customer-facing invoice access plus pluggable payment integration groundwork
 - **4D: Portal equipment view + invite/email flow**: Equipment history, invite activation, and customer notifications
 
-### Wave 5: Final Polish (active)
+### Wave 5: Final Polish (complete)
 
-- Capture missing screenshots (completed in Wave 5A)
-- Finalize sprint documentation
-- Run integration smoke tests (`make test-gate`)
-- Execute each Wave 5 lane from its own worktree/branch/PR with QA/security review before merge
+- Capture missing screenshots (completed in Wave 5A / [PR #62](https://github.com/llathrop/Dive_Service_Management/pull/62))
+- Finalize sprint documentation (completed in Wave 5B / [PR #64](https://github.com/llathrop/Dive_Service_Management/pull/64))
+- Run integration smoke tests (`make test-gate`, completed in Wave 5C / [PR #63](https://github.com/llathrop/Dive_Service_Management/pull/63))
+- Execute each Wave 5 lane from its own worktree/branch/PR with QA/security review before merge (completed)

--- a/scripts/final_wave_gate.sh
+++ b/scripts/final_wave_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-"${ROOT_DIR}/scripts/test-compose.sh" -f docker-compose.test.yml run --rm test python -m pytest \
+"${ROOT_DIR}/scripts/test-compose.sh" -f docker-compose.test.yml run --build --rm test python -m pytest \
   tests/smoke/ \
   tests/test_blueprints/test_health_extended.py \
   tests/validation/test_full_workflow.py \


### PR DESCRIPTION
## Summary
- mark final polish and Sprint 2026-03-22B complete in the planning docs
- make the final gate rebuild the Docker test image so it stays reproducible after dependency changes
- record the post-merge gate result on the progress log

## Verification
- ./scripts/final_wave_gate.sh